### PR TITLE
Change dashboard link to "Visit Pantheon Dashboard"

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -43,7 +43,7 @@ class Toolbar {
 				'id'     => 'pantheon-hud-dashboard-link',
 				'parent' => 'pantheon-hud',
 				'href'   => $dashboard_link,
-				'title'  => esc_html__( 'Visit Dashboard', 'pantheon-hud' ),
+				'title'  => esc_html__( 'Visit Pantheon Dashboard', 'pantheon-hud' ),
 				'meta'   => array(
 					'target' => '_blank',
 					),


### PR DESCRIPTION
"Visit Dashboard" is already a string used in WordPress, and therefore
ambigious.