### PR TITLE
Fix broken image link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ By default, the Pantheon HUD appears for logged-in users with the `manage_option
 ## Screenshots ##
 
 ### 1. Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links. ###
-![Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links.](http://s.wordpress.org/extend/plugins/pantheon-hud/screenshot-1.png)
+![Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links.](https://wordpress.org/extend/plugins/pantheon-hud/screenshot-1.png)
 
 
 ## Changelog ##


### PR DESCRIPTION
There was a typo in the image src.
