### PR TITLE
Define image dimensions inline instead of via CSS

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -29,7 +29,7 @@ class Toolbar {
 		$name = $api->get_site_name();
 		$site_id = $api->get_site_id();
 		$env = $this->get_environment();
-		$title = '<img src="' . esc_url( plugins_url( 'assets/img/pantheon-fist-color.svg', PANTHEON_HUD_ROOT_FILE ) ) . '" />';
+		$title = '<img src="' . esc_url( plugins_url( 'assets/img/pantheon-fist-color.svg', PANTHEON_HUD_ROOT_FILE ) ) . '" width="32" height="32" />';
 		$bits = array();
 		if ( $name ) {
 			$bits[] = $name;
@@ -117,8 +117,6 @@ class Toolbar {
 ?>
 <style>
 	#wpadminbar li#wp-admin-bar-pantheon-hud > .ab-item img {
-		height:32px;
-		width:32px;
 		vertical-align:middle;
 		margin-top:-4px;
 	}


### PR DESCRIPTION
It is a best practice for image dimensions to be defined inline instead of via CSS. This prevents bad things from happening if the CSS fails to load (for example if the stylesheet gets excluded in AMP if it goes over 50KB):

<img width="734" alt="screen shot 2018-07-06 at 11 35 20 am" src="https://user-images.githubusercontent.com/134745/42391003-796b322e-8113-11e8-8d52-f63e0cad0f1c.png">