### PR TITLE
Populate Pantheon HUD menu with an AJAX request on hover

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -71,7 +71,7 @@ class Toolbar {
 				'id'     => 'pantheon-hud-wp-admin-loading',
 				'parent' => 'pantheon-hud',
 				'href'   => false,
-				'title'  => 'Loading &hellip;',
+				'title'  => 'Loading&hellip;',
 			)
 		);
 

--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -167,6 +167,13 @@ jQuery('#wp-admin-bar-pantheon-hud').on('hover', function() {
 });
 EOT;
 		wp_add_inline_script( 'admin-bar', $script );
+add_filter(
+			'amp_dev_mode_element_xpaths',
+			static function( $xpaths ) {
+				$xpaths[] = '//script[ contains( text(), "wp-admin-bar-pantheon-hud" ) ]';
+				return $xpaths;
+			}
+		);
 		ob_start();
 		?>
 		<style>

--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -158,13 +158,29 @@ class Toolbar {
 			admin_url( 'admin-ajax.php' )
 		);
 		$script      = <<<EOT
-jQuery('#wp-admin-bar-pantheon-hud').on('hover', function() {
-	if (jQuery('#wp-admin-bar-pantheon-hud-wp-admin-loading').length) {
-		jQuery.get('{$request_url}', function(data) {
-			jQuery('#wp-admin-bar-pantheon-hud .ab-sub-wrapper').html(data);
-		});
+(function(){
+	var el = document.querySelector('#wp-admin-bar-pantheon-hud');
+	if ( ! el ) {
+		return;
 	}
-});
+	var fetchData = function() {
+		if ( ! document.querySelector('#wp-admin-bar-pantheon-hud-wp-admin-loading') ) {
+			return;
+		}
+		var request = new XMLHttpRequest();
+		request.open('GET', '{$request_url}', true);
+		request.onload = function() {
+			if (this.status >= 200 && this.status < 400) {
+				document.querySelector('#wp-admin-bar-pantheon-hud .ab-sub-wrapper').innerHTML = this.response;
+				el.removeEventListener('mouseover', fetchData);
+				el.removeEventListener('focus', fetchData);
+			}
+		};
+		request.send();
+	};
+	el.addEventListener('mouseover', fetchData);
+	el.addEventListener('focus', fetchData);
+}());
 EOT;
 		wp_add_inline_script( 'admin-bar', $script );
 add_filter(

--- a/pantheon-hud.php
+++ b/pantheon-hud.php
@@ -18,7 +18,7 @@ add_action(
 	'init',
 	function() {
 		$view_pantheon_hud = apply_filters( 'pantheon_hud_current_user_can_view', current_user_can( 'manage_options' ) );
-		if ( is_admin_bar_showing() && $view_pantheon_hud ) {
+		if ( $view_pantheon_hud ) {
 			Pantheon\HUD\Toolbar::get_instance();
 		}
 	}

--- a/tests/behat/pantheon-hud.feature
+++ b/tests/behat/pantheon-hud.feature
@@ -5,7 +5,4 @@ Feature: Solr Power plugin
 
   Scenario: Plugin is loaded
     When I go to "/wp-admin/"
-    Then the "#wp-admin-bar-pantheon-hud" element should contain "pantheon-hud.pantheonsite.io"
-    And the "#wp-admin-bar-pantheon-hud" element should contain "1 app container running PHP"
-    And the "#wp-admin-bar-pantheon-hud" element should contain "1 db container with replication disabled"
-    And the "#wp-admin-bar-pantheon-hud" element should contain "Visit Pantheon Dashboard"
+    Then the "#wp-admin-bar-pantheon-hud" element should contain "assets/img/pantheon-fist-color.svg"


### PR DESCRIPTION
Fixes #18 

![pantheonhud](https://user-images.githubusercontent.com/36432/74265824-11876200-4cb8-11ea-856e-8356289f679b.gif)


If you'd like to test it locally, drop this code snippet into a mu-plugin to mock a bunch of data:

```php
$_ENV['PANTHEON_ENVIRONMENT'] = 'dev';
$_ENV['PANTHEON_SITE']        = '73cae74a-b66e-440a-ad3b-4f0679eb5e97';
$_ENV['PANTHEON_SITE_NAME']   = 'daniel-pantheon';
$_ENV['php_version']          = '7.3';
define( 'PANTHEON_HUD_PHPUNIT_RUNNING', true );

add_filter(
	'pre_http_request',
	function( $response, $request, $url ) {
		$data_files = [
			'/sites/self/environments/dev/domains'  => 'domains.json',
			'/sites/self/environments/dev/settings' => 'environment-settings.json',
		];
		$path       = wp_parse_url( $url, PHP_URL_PATH );
		if ( ! isset( $data_files[ $path ] ) ) {
			return $response;
		}
		return array(
			'headers'  => array(
				'date'            => 'Thu, 14 Jan 2016 13:46:02 GMT',
				'content-type'    => 'application/json',
				'x-pantheon-host' => 'yggdrasil4ead8a2d.chios.panth.io',
				'server'          => 'TwistedWeb/12.2.0',
			),
			'body'     => file_get_contents( WP_PLUGIN_DIR . '/pantheon-hud/tests/phpunit/data/' . $data_files[ $path ] ), // phpcs:ignore WordPress.WP.AlternativeFunctions
			'response' => array(
				'code'    => 200,
				'message' => 'OK',
			),
			'cookies'  => array(),
			'filename' => null,
		);
	},
	10,
	3
);
```