### PR TITLE
Fix initialization of admin menu item on frontend

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -158,7 +158,7 @@ class Toolbar {
 			admin_url( 'admin-ajax.php' )
 		);
 		$script      = <<<EOT
-(function(){
+document.addEventListener( 'DOMContentLoaded', function() {
 	var el = document.querySelector('#wp-admin-bar-pantheon-hud');
 	if ( ! el ) {
 		return;
@@ -180,7 +180,7 @@ class Toolbar {
 	};
 	el.addEventListener('mouseover', fetchData);
 	el.addEventListener('focus', fetchData);
-}());
+} );
 EOT;
 		wp_add_inline_script( 'admin-bar', $script );
 add_filter(


### PR DESCRIPTION
When updating to the most recent version of pantheon-hud I noticed that the admin bar item didn't initialize on the frontend. The issue is that `document.querySelector('#wp-admin-bar-pantheon-hud')` returns no element at the point where the script is run. The fix is to defer it to `DOMContentLoaded`.

Fixes regression in #55.