### PR TITLE
update the status badge to use circleci rather than travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A heads-up display into your Pantheon environment.
 
 ## Description ##
 
-[![Build Status](https://travis-ci.org/pantheon-systems/pantheon-hud.svg?branch=master)](https://travis-ci.org/pantheon-systems/pantheon-hud)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/master)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support)
 
 This plugin provides situational awareness of the Pantheon plaform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.


### PR DESCRIPTION
Blocks [0.4.3 Release](https://github.com/pantheon-systems/pantheon-hud/pull/121). I would like to get this merged in prior to the release.