### PR TITLE
[CMSP-353] Add pantheon-wp-coding-standards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   lint:
     working_directory: ~/pantheon-systems/pantheon-hud
     docker:
-      - image: quay.io/pantheon-public/build-tools-ci:8.x-php8.2
+      - image: quay.io/pantheon-public/build-tools-ci:8.x-php8.0
     steps:
       - checkout
       - restore_cache:

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
             "@phpcs"
         ],
         "phpcs": "phpcs",
+        "phpcbf": "phpcbf",
         "phpunit": "phpunit",
         "test": "@phpunit"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,9 @@
         }
     ],
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
         "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
+        "pantheon-systems/pantheon-wp-coding-standards": "^1.0.0",
         "phpunit/phpunit": "^9",
-        "wp-coding-standards/wpcs": "dev-develop as 2.3.1",
-        "phpcompatibility/php-compatibility": "^9.3",
         "yoast/phpunit-polyfills": "^1.0",
         "symfony/yaml": "^5.4 || ^6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,61 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a848791f02a6ca2a18cbf9743ca1dee8",
+    "content-hash": "e1d3319dc1fc0e53d1e1e6d9b6627283",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "reference": "6cd0a6a82bc0ac988dbf9d6a7c2e293dc8ac640b",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
+                "php": ">=5.4",
+                "sirbrillig/phpcs-variable-analysis": "^2.11.1",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
+                "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Automattic/VIP-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress VIP minimum coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2021-09-29T16:20:23+00:00"
+        },
         {
             "name": "behat/behat",
             "version": "v3.12.0",
@@ -456,38 +508,35 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.4",
+                "php": ">=5.3",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "ext-json": "*",
-                "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "yoast/phpunit-polyfills": "^1.0"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -503,7 +552,7 @@
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -527,10 +576,10 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
-                "source": "https://github.com/PHPCSStandards/composer-installer"
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -661,6 +710,62 @@
             },
             "abandoned": "symfony/browser-kit",
             "time": "2020-11-01T09:30:18+00:00"
+        },
+        {
+            "name": "fig-r/psr2r-sniffer",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
+                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
+                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "slevomat/coding-standard": "^7.2.0 || ^8.3.0",
+                "spryker/code-sniffer": "^0.17.1",
+                "squizlabs/php_codesniffer": "^3.7.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0.0"
+            },
+            "bin": [
+                "bin/tokenize",
+                "bin/sniff"
+            ],
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "PSR2R\\": "PSR2R/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mark Scherer",
+                    "homepage": "https://www.dereuromark.de",
+                    "role": "Contributor"
+                }
+            ],
+            "description": "Code-Sniffer, Auto-Fixer and Tokenizer for PSR2-R",
+            "keywords": [
+                "codesniffer",
+                "cs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig-rectified/psr2r-sniffer/issues",
+                "source": "https://github.com/php-fig-rectified/psr2r-sniffer/tree/1.5.0"
+            },
+            "time": "2023-01-01T15:31:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1126,6 +1231,48 @@
             "time": "2020-04-17T11:46:11+00:00"
         },
         {
+            "name": "pantheon-systems/pantheon-wp-coding-standards",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
+                "reference": "9555c8e63b521380b4630fe16674ef7c97dd8873"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/9555c8e63b521380b4630fe16674ef7c97dd8873",
+                "reference": "9555c8e63b521380b4630fe16674ef7c97dd8873",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/vipwpcs": "^2.3",
+                "fig-r/psr2r-sniffer": "^1.5",
+                "phpcompatibility/phpcompatibility-wp": "^2.1",
+                "wp-coding-standards/wpcs": "^2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "9.6.x-dev",
+                "yoast/phpunit-polyfills": "1.x-dev"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pantheon",
+                    "email": "noreply@pantheon.io"
+                }
+            ],
+            "description": "PHPCS Rulesets for WordPress projects on Pantheon.",
+            "support": {
+                "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
+                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.0"
+            },
+            "time": "2023-02-17T16:16:30+00:00"
+        },
+        {
             "name": "phar-io/manifest",
             "version": "2.0.3",
             "source": {
@@ -1299,141 +1446,161 @@
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.0.3",
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/7029c051cd310e2e17c6caea3429bfbe290c41ae",
-                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.5",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
+                    "name": "Wim Godden",
                     "role": "lead"
                 },
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
                 }
             ],
-            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
             "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
+                "compatibility",
+                "paragonie",
                 "phpcs",
+                "polyfill",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2023-03-28T17:48:27+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
-            "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.2",
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "e74812ac026d9f9f18a936d29880b2db3211f89d"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/e74812ac026d9f9f18a936d29880b2db3211f89d",
-                "reference": "e74812ac026d9f9f18a936d29880b2db3211f89d",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "ext-filter": "*",
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.3",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3",
-                "yoast/phpunit-polyfills": "^1.0.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHPCSUtils/"
-                ]
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
             ],
             "authors": [
                 {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
+                    "name": "Wim Godden",
                     "role": "lead"
                 },
                 {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
                 }
             ],
-            "description": "A suite of utility functions for use with PHP_CodeSniffer",
-            "homepage": "https://phpcsutils.com/",
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
             "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
+                "compatibility",
                 "phpcs",
-                "phpcs3",
                 "standards",
                 "static analysis",
-                "tokens",
-                "utility"
+                "wordpress"
             ],
             "support": {
-                "docs": "https://phpcsutils.com/",
-                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2023-03-28T16:57:37+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "reference": "22dcdfd725ddf99583bfe398fc624ad6c5004a0f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.18.1"
+            },
+            "time": "2023-04-07T11:51:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1755,16 +1922,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.6",
+            "version": "9.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
-                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
+                "reference": "c993f0d3b0489ffc42ee2fe0bd645af1538a63b2",
                 "shasum": ""
             },
             "require": {
@@ -1838,7 +2005,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.7"
             },
             "funding": [
                 {
@@ -1854,7 +2021,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:43:46+00:00"
+            "time": "2023-04-14T08:58:40+00:00"
         },
         {
             "name": "psr/container",
@@ -3014,6 +3181,187 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "sirbrillig/phpcs-variable-analysis",
+            "version": "v2.11.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "reference": "dc5582dc5a93a235557af73e523c389aac9a8e88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+            },
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "VariableAnalysis\\": "VariableAnalysis/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sam Graham",
+                    "email": "php-codesniffer-variableanalysis@illusori.co.uk"
+                },
+                {
+                    "name": "Payton Swick",
+                    "email": "payton@foolord.com"
+                }
+            ],
+            "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2023-03-31T16:46:32+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "c4e213e6e57f741451a08e68ef838802eec92287"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/c4e213e6e57f741451a08e68ef838802eec92287",
+                "reference": "c4e213e6e57f741451a08e68ef838802eec92287",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.18.0 <1.19.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.4.10|1.10.11",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.0.0|1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.6|10.0.19"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-04-10T07:39:29+00:00"
+        },
+        {
+            "name": "spryker/code-sniffer",
+            "version": "0.17.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spryker/code-sniffer.git",
+                "reference": "5fb8b573abc4a906d0d364a4a03abd38e565ba29"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spryker/code-sniffer/zipball/5fb8b573abc4a906d0d364a4a03abd38e565ba29",
+                "reference": "5fb8b573abc4a906d0d364a4a03abd38e565ba29",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "slevomat/coding-standard": "^7.2.0 || ^8.0.1",
+                "squizlabs/php_codesniffer": "^3.6.2"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "bin": [
+                "bin/tokenize"
+            ],
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "Spryker\\": "Spryker/",
+                    "SprykerStrict\\": "SprykerStrict/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Spryker",
+                    "homepage": "https://spryker.com"
+                }
+            ],
+            "description": "Spryker Code Sniffer Standards",
+            "homepage": "https://spryker.com",
+            "keywords": [
+                "codesniffer",
+                "framework",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/spryker/code-sniffer/issues",
+                "source": "https://github.com/spryker/code-sniffer"
+            },
+            "time": "2023-01-03T16:08:22+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5037,36 +5385,31 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "dev-develop",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "2e76b2061246fbee2ea8461c57b67b6b0c010223"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/2e76b2061246fbee2ea8461c57b67b6b0c010223",
-                "reference": "2e76b2061246fbee2ea8461c57b67b6b0c010223",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
-                "ext-filter": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.0",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.2"
+                "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "ext-mbstring": "For improved results"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -5082,7 +5425,6 @@
             "keywords": [
                 "phpcs",
                 "standards",
-                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -5090,7 +5432,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-03-27T21:12:05+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -5153,18 +5495,10 @@
             "time": "2023-03-30T23:39:05+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "wp-coding-standards/wpcs",
-            "version": "dev-develop",
-            "alias": "2.3.1",
-            "alias_normalized": "2.3.1.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "pantheon-systems/pantheon-wordpress-upstream-tests": 20,
-        "wp-coding-standards/wpcs": 20
+        "pantheon-systems/pantheon-wordpress-upstream-tests": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -1232,16 +1232,16 @@
         },
         {
             "name": "pantheon-systems/pantheon-wp-coding-standards",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards.git",
-                "reference": "9555c8e63b521380b4630fe16674ef7c97dd8873"
+                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/9555c8e63b521380b4630fe16674ef7c97dd8873",
-                "reference": "9555c8e63b521380b4630fe16674ef7c97dd8873",
+                "url": "https://api.github.com/repos/pantheon-systems/Pantheon-WP-Coding-Standards/zipball/1e8fb654d52b9274f548c46f89d98f4913307fdf",
+                "reference": "1e8fb654d52b9274f548c46f89d98f4913307fdf",
                 "shasum": ""
             },
             "require": {
@@ -1268,9 +1268,9 @@
             "description": "PHPCS Rulesets for WordPress projects on Pantheon.",
             "support": {
                 "issues": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/issues",
-                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.0"
+                "source": "https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/tree/1.0.1"
             },
-            "time": "2023-02-17T16:16:30+00:00"
+            "time": "2023-04-14T16:54:02+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/inc/class-api.php
+++ b/inc/class-api.php
@@ -86,18 +86,17 @@ class API {
 	 * @return array
 	 */
 	public function get_environment_details() {
-		$env                  = ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ? $_ENV['PANTHEON_ENVIRONMENT'] : 'dev';
-		$details              = array(
-			'web'      => array(),
-			'database' => array(),
-		);
+		$details = [
+			'web' => [],
+			'database' => [],
+		];
 		$environment_settings = $this->get_environment_settings_data();
 		if ( ! empty( $environment_settings['appserver'] ) ) {
 			$details['web']['appserver_count'] = $environment_settings['appserver'];
 		}
 		$php_version = $this->get_php_version();
 		if ( $php_version ) {
-			$php_version                   = (string) $php_version;
+			$php_version = (string) $php_version;
 			$details['web']['php_version'] = 'PHP ' . $php_version;
 		}
 		if ( ! empty( $environment_settings['dbserver'] ) ) {
@@ -129,10 +128,10 @@ class API {
 			return $this->domains_data[ $env ];
 		}
 		if ( ! empty( $env ) ) {
-			$url                        = sprintf( '%s/sites/self/environments/%s/domains', self::API_URL_BASE, $env );
+			$url = sprintf( '%s/sites/self/environments/%s/domains', self::API_URL_BASE, $env );
 			$this->domains_data[ $env ] = self::fetch_api_data( $url );
 		} else {
-			$this->domains_data[ $env ] = array();
+			$this->domains_data[ $env ] = [];
 		}
 		return $this->domains_data[ $env ];
 	}
@@ -147,10 +146,10 @@ class API {
 			return $this->environment_settings_data;
 		}
 		if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
-			$url                             = sprintf( '%s/sites/self/environments/%s/settings', self::API_URL_BASE, $_ENV['PANTHEON_ENVIRONMENT'] );
+			$url = sprintf( '%s/sites/self/environments/%s/settings', self::API_URL_BASE, $_ENV['PANTHEON_ENVIRONMENT'] );
 			$this->environment_settings_data = self::fetch_api_data( $url );
 		} else {
-			$this->environment_settings_data = array();
+			$this->environment_settings_data = [];
 		}
 		return $this->environment_settings_data;
 	}
@@ -166,15 +165,15 @@ class API {
 		// Function internal to Pantheon infrastructure.
 		$pem_file = apply_filters( 'pantheon_hud_pem_file', null );
 		if ( function_exists( 'pantheon_curl' ) ) {
-			$bits     = wp_parse_url( $url );
+			$bits = wp_parse_url( $url );
 			$response = pantheon_curl( sprintf( '%s://%s%s', $bits['scheme'], $bits['host'], $bits['path'] ), null, $bits['port'] );
-			$body     = ! empty( $response['body'] ) ? $response['body'] : '';
+			$body = ! empty( $response['body'] ) ? $response['body'] : '';
 			return json_decode( $body, true );
 
 			// For those developing locally who know what they're doing.
 		} elseif ( $pem_file || ( defined( 'PANTHEON_HUD_PHPUNIT_RUNNING' ) && PANTHEON_HUD_PHPUNIT_RUNNING ) ) {
 			$require_curl = function() {
-				return array( 'curl' );
+				return [ 'curl' ];
 			};
 			add_filter( 'http_api_transports', $require_curl );
 			$client_cert = function( $handle ) use ( $pem_file ) {
@@ -183,22 +182,20 @@ class API {
 			add_action( 'http_api_curl', $client_cert );
 			$response = wp_remote_get(
 				$url,
-				array(
-					'sslverify' => false, // yolo.
-				)
+				[ 'sslverify' => false ] // yolo.
 			);
 			if ( is_wp_error( $response ) ) {
-				return array();
+				return [];
 			}
 			remove_action( 'http_api_curl', $client_cert );
 			remove_filter( 'http_api_transports', $require_curl );
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				return array();
+				return [];
 			}
 			$body = wp_remote_retrieve_body( $response );
 			return json_decode( $body, true );
 		}
-		return array();
+		return [];
 	}
 
 }

--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -35,10 +35,10 @@ class Toolbar {
 	 * Setup Actions
 	 */
 	private function setup_actions() {
-		add_action( 'admin_bar_menu', array( $this, 'action_admin_bar_menu' ), 100 );
-		add_action( 'wp_ajax_pantheon_hud_markup', array( $this, 'action_handle_ajax_markup' ) );
-		add_action( 'wp_enqueue_scripts', array( $this, 'add_admin_bar_inline_styles' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'add_admin_bar_inline_styles' ) );
+		add_action( 'admin_bar_menu', [ $this, 'action_admin_bar_menu' ], 100 );
+		add_action( 'wp_ajax_pantheon_hud_markup', [ $this, 'action_handle_ajax_markup' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'add_admin_bar_inline_styles' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'add_admin_bar_inline_styles' ] );
 	}
 
 	/**
@@ -47,33 +47,28 @@ class Toolbar {
 	 * @param object $wp_admin_bar The Admin Bar Object.
 	 */
 	public function action_admin_bar_menu( $wp_admin_bar ) {
-		$api     = new API();
-		$name    = $api->get_site_name();
-		$site_id = $api->get_site_id();
-		$env     = $this->get_environment();
-		$title   = '<img src="' . esc_url( plugins_url( 'assets/img/pantheon-fist-color.svg', PANTHEON_HUD_ROOT_FILE ) ) . '" width="32" height="32" />';
-		$bits    = array();
+		$api = new API();
+		$name = $api->get_site_name();
+		$env = $this->get_environment();
+		$title = '<img src="' . esc_url( plugins_url( 'assets/img/pantheon-fist-color.svg', PANTHEON_HUD_ROOT_FILE ) ) . '" width="32" height="32" />';
+		$bits = [];
 		if ( $name ) {
 			$bits[] = $name;
 		}
 		$bits[] = $env;
 		$title .= ' ' . esc_html( strtolower( implode( ':', $bits ) ) );
-		$wp_admin_bar->add_node(
-			array(
-				'id'    => 'pantheon-hud',
-				'href'  => false,
-				'title' => $title,
-			)
-		);
+		$wp_admin_bar->add_node( [
+			'id' => 'pantheon-hud',
+			'href' => false,
+			'title' => $title,
+		] );
 
-		$wp_admin_bar->add_node(
-			array(
-				'id'     => 'pantheon-hud-wp-admin-loading',
-				'parent' => 'pantheon-hud',
-				'href'   => false,
-				'title'  => 'Loading&hellip;',
-			)
-		);
+		$wp_admin_bar->add_node( [
+			'id' => 'pantheon-hud-wp-admin-loading',
+			'parent' => 'pantheon-hud',
+			'href' => false,
+			'title' => 'Loading&hellip;',
+		] );
 	}
 
 	/**
@@ -82,16 +77,16 @@ class Toolbar {
 	public function action_handle_ajax_markup() {
 		check_ajax_referer( 'pantheon_hud' );
 
-		$api      = new API();
-		$name     = $api->get_site_name();
-		$site_id  = $api->get_site_id();
-		$env      = $this->get_environment();
-		$markup   = array();
+		$api = new API();
+		$name = $api->get_site_name();
+		$site_id = $api->get_site_id();
+		$env = $this->get_environment();
+		$markup = [];
 		$markup[] = '<ul id="wp-admin-bar-pantheon-hud-default" class="ab-submenu">';
 
 		$env_admins = '';
 		// TODO: List envs from API to include Multidev.
-		foreach ( array( 'dev', 'test', 'live' ) as $e ) {
+		foreach ( [ 'dev', 'test', 'live' ] as $e ) {
 			$url = $api->get_primary_environment_url( $e );
 			if ( $url ) {
 				$env_admins .= '<a target="_blank" href="' . esc_url( rtrim( $url ) . '/wp-admin/' ) . '">' . esc_html( $e ) . '</a> | ';
@@ -99,12 +94,12 @@ class Toolbar {
 		}
 
 		if ( ! empty( $env_admins ) ) {
-			$markup[] = '<li id="wp-admin-bar-pantheon-hud-wp-admin-links"><div class="ab-item ab-empty-item">' . '<em>wp-admin links</em><br />' . rtrim( $env_admins, ' |' ) . '</div></li>';
+			$markup[] = '<li id="wp-admin-bar-pantheon-hud-wp-admin-links"><div class="ab-item ab-empty-item"><em>wp-admin links</em><br />' . rtrim( $env_admins, ' |' ) . '</div></li>';
 		}
 
 		$environment_details = $api->get_environment_details();
 		if ( $environment_details ) {
-			$details_html = array();
+			$details_html = [];
 			if ( isset( $environment_details['web']['appserver_count'] ) ) {
 				$pluralize  = $environment_details['web']['appserver_count'] > 1 ? 's' : '';
 				$web_detail = $environment_details['web']['appserver_count'] . ' app container' . $pluralize;
@@ -138,7 +133,7 @@ class Toolbar {
 		}
 
 		$markup[] = '</ul>';
-		echo implode( PHP_EOL, $markup );
+		echo implode( PHP_EOL, $markup ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		exit;
 	}
 
@@ -150,10 +145,10 @@ class Toolbar {
 			return;
 		}
 		$request_url = add_query_arg(
-			array(
+			[
 				'action'   => 'pantheon_hud_markup',
 				'_wpnonce' => wp_create_nonce( 'pantheon_hud' ),
-			),
+			],
 			admin_url( 'admin-ajax.php' )
 		);
 		$script      = <<<EOT
@@ -233,7 +228,7 @@ EOT;
 			}
 		</style>
 		<?php
-		wp_add_inline_style( 'admin-bar', str_replace( array( '<style>', '</style>' ), '', ob_get_clean() ) );
+		wp_add_inline_style( 'admin-bar', str_replace( [ '<style>', '</style>' ], '', ob_get_clean() ) );
 	}
 
 	/**

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,6 +9,7 @@
 	<!-- Show sniff codes in all reports -->
 	<arg value="ps"/>
 
+	<rule ref="Pantheon-WP-Coding-Standards" />
 	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,7 +10,6 @@
 	<arg value="ps"/>
 
 	<rule ref="Pantheon-WP-Coding-Standards" />
-	<rule ref="WordPress-Core" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,6 +13,9 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>
 
+	<!-- Explicitly exclude this VIP rule against wp_remote_get. To be updated in Pantheon-WP standards. see https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2 -->
+	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
+
 	<!-- Minimum PHP and WP versions -->
 	<config name="testVersion" value="7.1-"/>
 	<config name="minimum_supported_wp_version" value="4.4"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,11 +9,7 @@
 	<!-- Show sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<rule ref="Pantheon-WP">
-		<!-- Explicitly exclude this VIP rule against wp_remote_get. To be updated in Pantheon-WP standards. see https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2 -->
-		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
-		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
-	</rule>
+	<rule ref="Pantheon-WP" />
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,7 +9,7 @@
 	<!-- Show sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<rule ref="Pantheon-WP-Coding-Standards">
+	<rule ref="Pantheon-WP">
 		<!-- Explicitly exclude this VIP rule against wp_remote_get. To be updated in Pantheon-WP standards. see https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2 -->
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,12 +9,14 @@
 	<!-- Show sniff codes in all reports -->
 	<arg value="ps"/>
 
-	<rule ref="Pantheon-WP-Coding-Standards" />
+	<rule ref="Pantheon-WP-Coding-Standards">
+		<!-- Explicitly exclude this VIP rule against wp_remote_get. To be updated in Pantheon-WP standards. see https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2 -->
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
+		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
+	</rule>
 	<rule ref="WordPress-Docs" />
 	<rule ref="PHPCompatibility"/>
 
-	<!-- Explicitly exclude this VIP rule against wp_remote_get. To be updated in Pantheon-WP standards. see https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2 -->
-	<rule ref="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
 
 	<!-- Minimum PHP and WP versions -->
 	<config name="testVersion" value="7.1-"/>


### PR DESCRIPTION
Adds our coding standard and makes some fixes.

There are two VIP rules that need to be excluded from the standard itself that are being manually excluded here as a short term solution. See https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards/pull/2

This also adjusts the PHP version in the linting box in CI to 8.0 so it's compatible with our standard.