### PR TITLE
Lint README for lost spacing

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,6 +22,13 @@ jobs:
       - uses: pantheon-systems/action-wporg-validator@1.0.0
         with:
           type: 'plugin'
+  validate-readme-spacing:
+    name: Validate README Spacing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: pantheon-systems/validate-readme-spacing@v1
   test-phpunit-74:
     needs: lint
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Pantheon HUD #
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
-**Tags:** Pantheon, hosting 
+**Tags:** Pantheon, hosting  
 **Requires at least:** 4.9  
 **Tested up to:** 6.2  
 **Stable tag:** 0.4.4-dev  
 **License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
 A heads-up display into your Pantheon environment.
 


### PR DESCRIPTION
Ensures the header section of README.md handles newlines correctly in rendered markdown.

See https://github.com/pantheon-systems/validate-readme-spacing