### PR TITLE
Switch to using main/release rather than develop/main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
     jobs:
       - test-behat
 jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
     * `git checkout develop`
     * `git rebase release`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
-    * Add a new `** Latest **` heading to the changelog
+    * Add a new `** X.Y.Z-dev **` heading to the changelog where `X.Y.Z-dev` is the new patch version.
     * `git add -A .`
     * `git commit -m "Prepare X.Y.X-dev"`
     * `git push origin develop`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,13 @@ Please feel free to file issues there. Pull requests are also welcome!
 
 ## Workflow
 
-The `develop` branch is the development branch which means it contains the next version to be released. `main` contains the corresponding stable development version. Always work on the `develop` branch and open up PRs against `develop`.
+The `main` branch is the development branch which means it contains the next version to be released. `release` contains the corresponding stable development version. Always work on the `main` branch and open up PRs against `main`.
 
-We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `develop` when merging, and to include the PR # in the commit message. PRs to `develop` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `develop`.
+We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `main` when merging, and to include the PR # in the commit message. PRs to `main` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `main`.
 
-`develop` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
+`main` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 
-The `main` branch matches the latest stable release deployed to [wp.org](wp.org).
+The `release` branch matches the latest stable release deployed to [wp.org](wp.org).
 
 ## Testing
 
@@ -35,21 +35,21 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
 ## Release Process
 
 1. Make a release commit:
-1. From `develop`, checkout a new branch `release_X.Y.Z`.
+1. From `main`, checkout a new branch `release_X.Y.Z`.
     * Drop the `-dev` from the version number in `package.json`, `README.md`, `readme.txt`, and `pantheon-hud.php`.
     * Update the "Latest" heading in the changelog to the new version number with the date
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
-1. Open a Pull Request to merge `release_X.Y.Z` into `main`. Your PR should consist of all commits to `develop` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
-1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `main`.
-1. Pull `main` locally, create a new tag, and push up.
+1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `main` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
+1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `release`.
+1. Pull `release` locally, create a new tag, and push up.
 1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
 1. Create a [new release](https://github.com/pantheon-systems/pantheon-hud/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.
 1. Wait for the [_Release pantheon-hud plugin to wp.org_ action](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.
 1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/pantheon-hud/). This may take a few minutes.
 1. Following the release, prepare the next dev version with the following steps:
     * `git checkout develop`
-    * `git rebase main`
+    * `git rebase release`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
     * Add a new `** Latest **` heading to the changelog
     * `git add -A .`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
 1. From `main`, checkout a new branch `release_X.Y.Z`.
 1. Make a release commit:
     * Drop the `-dev` from the version number in `package.json`, `README.md`, `readme.txt`, and `pantheon-hud.php`.
-    * Update the "Latest" heading in the changelog to the new version number with the date
+    * Update the "X.Y.Z-dev" heading in the changelog to the new version number with the date
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `main` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please feel free to file issues there. Pull requests are also welcome!
 
 ## Workflow
 
-Development and releases are structured around two branches, `develop` and `master`. The `develop` branch is the default branch for the repository, and is the source and destination for feature branches.
+The `develop` branch is the development branch which means it contains the next version to be released. `main` contains the corresponding stable development version. Always work on the `develop` branch and open up PRs against `develop`.
 
 We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `develop` when merging, and to include the PR # in the commit message. PRs to `develop` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `develop`.
 
@@ -34,15 +34,15 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
 
 ## Release Process
 
-1. From `develop`, checkout a new branch `release_X.Y.Z`.
 1. Make a release commit:
+1. From `develop`, checkout a new branch `release_X.Y.Z`.
     * Drop the `-dev` from the version number in `package.json`, `README.md`, `readme.txt`, and `pantheon-hud.php`.
     * Update the "Latest" heading in the changelog to the new version number with the date
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `main`. Your PR should consist of all commits to `develop` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
-1. After all tests pass and you have received approval from a [CODEOWNER](./CODEOWNERS), merge the PR into `master`. "Rebase and merge" is preferred in this case. _Never_ squash to `master`.
-1. Pull `master` locally, create a new tag (based on version number from previous steps), and push up. The tag should _only_ be the version number. It _should not_ be prefixed  `v` (i.e. `X.Y.Z`, not `vX.Y.X`).
+1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `main`.
+1. Pull `main` locally, create a new tag, and push up.
 1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
 1. Create a [new release](https://github.com/pantheon-systems/pantheon-hud/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.
 1. Wait for the [_Release pantheon-hud plugin to wp.org_ action](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/wordpress-plugin-deploy.yml) to finish deploying to the WordPress.org plugin repository. If all goes well, users with SVN commit access for that plugin will receive an emailed diff of changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `d
 
 `develop` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 
-The `master` branch matches the latest stable release deployed to [wp.org](wp.org).
+The `main` branch matches the latest stable release deployed to [wp.org](wp.org).
 
 ## Testing
 
@@ -49,7 +49,7 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
 1. Check WordPress.org: Ensure that the changes are live on [the plugin repository](https://wordpress.org/plugins/pantheon-hud/). This may take a few minutes.
 1. Following the release, prepare the next dev version with the following steps:
     * `git checkout develop`
-    * `git rebase master`
+    * `git rebase main`
     * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
     * Add a new `** Latest **` heading to the changelog
     * `git add -A .`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,8 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
 
 ## Release Process
 
-1. Make a release commit:
 1. From `main`, checkout a new branch `release_X.Y.Z`.
+1. Make a release commit:
     * Drop the `-dev` from the version number in `package.json`, `README.md`, `readme.txt`, and `pantheon-hud.php`.
     * Update the "Latest" heading in the changelog to the new version number with the date
     * Commit these changes with the message `Release X.Y.Z`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
     * Commit these changes with the message `Release X.Y.Z`
     * Push the release branch up.
 1. Open a Pull Request to merge `release_X.Y.Z` into `release`. Your PR should consist of all commits to `main` since the last release, and one commit to update the version number. The PR name should also be `Release X.Y.Z`.
-1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `release`.
+1. After all tests pass and you have received approval from a CODEOWNER (including resolving any merge conflicts), merge the PR into `release`. Use a "merge" commit, do no not rebase or squash.
 1. Pull `release` locally, create a new tag, and push up.
 1. Confirm that the necessary assets are present in the newly created tag, and test on a WP install if desired.
 1. Create a [new release](https://github.com/pantheon-systems/pantheon-hud/releases/new) using the tag created in the previous steps, naming the release with the new version number, and targeting the tag created in the previous step. Paste the release changelog from the `Changelog` section of [the readme](readme.txt) into the body of the release, including the links to the closed issues if applicable.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,7 +12,7 @@ module.exports = function( grunt ) {
 					'README.md': 'readme.txt'
 				},
 				options: {
-					screenshot_url: 'https://raw.githubusercontent.com/pantheon-systems/pantheon-hud/master/{screenshot}.png',
+					screenshot_url: 'https://raw.githubusercontent.com/pantheon-systems/pantheon-hud/main/{screenshot}.png',
 				},
 			},
 		},

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon HUD #
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
-**Tags:** Pantheon, hosting  
+**Tags:** Pantheon, hosting, environment-indicator  
 **Requires at least:** 4.9  
 **Tested up to:** 6.3.1  
 **Stable tag:** 0.4.4-dev  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
-**Tags:** Pantheon, hosting, environment-indicator  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
+**Tags:** Pantheon, hosting  
 **Requires at least:** 4.9  
 **Tested up to:** 6.3  
 **Stable tag:** 0.4.4-dev  
@@ -11,8 +11,7 @@ A heads-up display into your Pantheon environment.
 
 ## Description ##
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/master)
-[![Lint & Test](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/main)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support)
 
 This plugin provides situational awareness of the Pantheon plaform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.
@@ -36,7 +35,7 @@ By default, the Pantheon HUD appears for logged-in users with the `manage_option
 ## Screenshots ##
 
 ### 1. Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links. ###
-![Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links.](https://raw.githubusercontent.com/pantheon-systems/pantheon-hud/master/screenshot-1.png)
+![Pantheon HUD is present in the WordPress toolbar. On hover, it displays environmental details and helpful links.](https://raw.githubusercontent.com/pantheon-systems/pantheon-hud/main/screenshot-1.png)
 
 
 ## Changelog ##

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
 **Tags:** Pantheon, hosting  
 **Requires at least:** 4.9  
-**Tested up to:** 6.3  
+**Tested up to:** 6.3.1  
 **Stable tag:** 0.4.4-dev  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A heads-up display into your Pantheon environment.
 
 ## Description ##
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/master)
+[![Lint & Test](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support)
 
 This plugin provides situational awareness of the Pantheon plaform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -28,7 +28,7 @@ set -ex
 # Apply any outstanding upstream updates.
 # This never happens manually, so we might as well do it in automation before we run tests.
 ###
-terminus upstream:updates:apply $TERMINUS_SITE.$TERMINUS_ENV --accept-upstream
+terminus upstream:updates:apply $TERMINUS_SITE.dev --accept-upstream
 
 ###
 # Create a new environment for this particular test run.

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -28,7 +28,7 @@ set -ex
 # Apply any outstanding upstream updates.
 # This never happens manually, so we might as well do it in automation before we run tests.
 ###
-terminus connection:set $SITE_ENV git
+terminus connection:set $TERMINUS_SITE.dev git
 terminus upstream:updates:apply $TERMINUS_SITE.dev --accept-upstream
 
 ###

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -28,6 +28,7 @@ set -ex
 # Apply any outstanding upstream updates.
 # This never happens manually, so we might as well do it in automation before we run tests.
 ###
+terminus connection:set $SITE_ENV git
 terminus upstream:updates:apply $TERMINUS_SITE.dev --accept-upstream
 
 ###
@@ -47,7 +48,6 @@ BASH_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 ###
 # Switch to git mode for pushing the files up
 ###
-terminus connection:set $SITE_ENV git
 rm -rf $PREPARE_DIR
 git clone -b $TERMINUS_ENV $PANTHEON_GIT_URL $PREPARE_DIR
 

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -25,11 +25,16 @@ fi
 set -ex
 
 ###
-# Apply any outstanding upstream updates.
+# Check for and apply any outstanding upstream updates.
 # This never happens manually, so we might as well do it in automation before we run tests.
 ###
 terminus connection:set $TERMINUS_SITE.dev git
-terminus upstream:updates:apply $TERMINUS_SITE.dev --accept-upstream
+updates=$(terminus upstream:updates:list "$TERMINUS_SITE.dev")
+if echo "$updates" | grep -q "There are no available updates for this site."; then
+  echo "No upstream updates to apply."
+else
+  terminus upstream:updates:apply "$TERMINUS_SITE.dev" --accept-upstream
+fi
 
 ###
 # Create a new environment for this particular test run.

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -25,6 +25,12 @@ fi
 set -ex
 
 ###
+# Apply any outstanding upstream updates.
+# This never happens manually, so we might as well do it in automation before we run tests.
+###
+terminus upstream:updates:apply $TERMINUS_SITE.$TERMINUS_ENV --accept-upstream
+
+###
 # Create a new environment for this particular test run.
 ###
 terminus env:create  $TERMINUS_SITE.dev $TERMINUS_ENV

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -20,9 +20,6 @@ if [ -z "$WORDPRESS_ADMIN_USERNAME" ] || [ -z "$WORDPRESS_ADMIN_PASSWORD" ]; the
 	exit 1
 fi
 
-# Activate the twentytwentythree theme.
-terminus wp $TERMINUS_SITE.$TERMINUS_ENV -- theme activate twentytwentythree
-
 set -ex
 
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io"} }}'

--- a/bin/behat-test.sh
+++ b/bin/behat-test.sh
@@ -20,6 +20,9 @@ if [ -z "$WORDPRESS_ADMIN_USERNAME" ] || [ -z "$WORDPRESS_ADMIN_PASSWORD" ]; the
 	exit 1
 fi
 
+# Activate the twentytwentythree theme.
+terminus wp $TERMINUS_SITE.$TERMINUS_ENV -- theme activate twentytwentythree
+
 set -ex
 
 export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://'$TERMINUS_ENV'-'$TERMINUS_SITE'.pantheonsite.io"} }}'

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -45,7 +45,6 @@ main(){
     elif [ $compare_result == "0" ]; then
         echo "${FIXTURE_VERSION} is equal to ${TESTED_UP_TO}"
         echo "No action required."
-        exit 0
     else
         echo "An error occurred during version comparison."
         exit 1

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -36,7 +36,7 @@ main(){
 
     if [ $compare_result == "-1" ]; then
         echo "${FIXTURE_VERSION} is greater than ${TESTED_UP_TO}"
-        echo "You should update the 'Tested up to' in your plugin's readme.txt"
+        echo "You should update the 'Tested up to' in your plugin's readme.txt to '${FIXTURE_VERSION}'."
         exit 1
 	elif [ $compare_result == "1" ]; then
         echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -32,9 +32,23 @@ main(){
     FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
     echo "Fixture Version: ${FIXTURE_VERSION}"
 
-    if ! php -r "exit(version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}'));"; then
+    php -r "exit(version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}'));"
+    exit_code=$?
+
+    if [ $exit_code -eq 255 ]; then
+        echo "An error occurred during version comparison."
+        exit 1
+    elif [ $exit_code -eq 1 ]; then
         echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"
         echo "Please update ${TERMINUS_SITE} to at least WordPress ${TESTED_UP_TO}"
+        exit 1
+    elif [ $exit_code -eq 0 ]; then
+        echo "${FIXTURE_VERSION} is equal to ${TESTED_UP_TO}"
+        echo "No action required."
+        exit 0
+    else
+        echo "${FIXTURE_VERSION} is greater than ${TESTED_UP_TO}"
+        echo "You should update the 'Tested up to' in your plugin's readme.txt"
         exit 1
     fi
 }

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -32,23 +32,22 @@ main(){
     FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
     echo "Fixture Version: ${FIXTURE_VERSION}"
 
-    php -r "exit(version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}'));"
-    exit_code=$?
+    compare_result=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}');")
 
-    if [ $exit_code -eq 255 ]; then
-        echo "An error occurred during version comparison."
+    if [ $compare_result == "-1" ]; then
+        echo "${FIXTURE_VERSION} is greater than ${TESTED_UP_TO}"
+        echo "You should update the 'Tested up to' in your plugin's readme.txt"
         exit 1
-    elif [ $exit_code -eq 1 ]; then
+	elif [ $compare_result == "1" ]; then
         echo "${FIXTURE_VERSION} is less than ${TESTED_UP_TO}"
         echo "Please update ${TERMINUS_SITE} to at least WordPress ${TESTED_UP_TO}"
         exit 1
-    elif [ $exit_code -eq 0 ]; then
+    elif [ $compare_result == "0" ]; then
         echo "${FIXTURE_VERSION} is equal to ${TESTED_UP_TO}"
         echo "No action required."
         exit 0
     else
-        echo "${FIXTURE_VERSION} is greater than ${TESTED_UP_TO}"
-        echo "You should update the 'Tested up to' in your plugin's readme.txt"
+        echo "An error occurred during version comparison."
         exit 1
     fi
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "495907a95f131d852721af5a9bdc4055",
+    "content-hash": "762aedeb842219cbe0204d08822e130a",
     "packages": [],
     "packages-dev": [
         {
@@ -589,30 +589,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.5.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
+                "doctrine/coding-standard": "^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
             },
             "type": "library",
             "autoload": {
@@ -639,7 +639,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
             },
             "funding": [
                 {
@@ -655,7 +655,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:15:36+00:00"
+            "time": "2022-12-30T00:23:10+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -719,16 +719,16 @@
         },
         {
             "name": "fig-r/psr2r-sniffer",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig-rectified/psr2r-sniffer.git",
-                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2"
+                "reference": "c950b88ed7ad8ae115e11896bbe36d5896aa4f36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
-                "reference": "53ca1ecd62b0dc2ab8ea48635f583cb361c5e8f2",
+                "url": "https://api.github.com/repos/php-fig-rectified/psr2r-sniffer/zipball/c950b88ed7ad8ae115e11896bbe36d5896aa4f36",
+                "reference": "c950b88ed7ad8ae115e11896bbe36d5896aa4f36",
                 "shasum": ""
             },
             "require": {
@@ -769,9 +769,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig-rectified/psr2r-sniffer/issues",
-                "source": "https://github.com/php-fig-rectified/psr2r-sniffer/tree/1.5.0"
+                "source": "https://github.com/php-fig-rectified/psr2r-sniffer/tree/1.5.1"
             },
-            "time": "2023-01-01T15:31:05+00:00"
+            "time": "2023-09-23T19:16:19+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1547,16 +1547,16 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc"
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/98bcdbacbda14b1db85f710b1853125726795bbc",
-                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+                "reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
                 "shasum": ""
             },
             "require": {
@@ -1606,7 +1606,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-08-26T04:46:45+00:00"
+            "time": "2023-09-20T22:06:18+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
@@ -1683,16 +1683,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.24.0",
+            "version": "1.24.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6"
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/3510b0a6274cc42f7219367cb3abfc123ffa09d6",
-                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/bcad8d995980440892759db0c32acae7c8e79442",
+                "reference": "bcad8d995980440892759db0c32acae7c8e79442",
                 "shasum": ""
             },
             "require": {
@@ -1724,22 +1724,22 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.2"
             },
-            "time": "2023-09-07T20:46:32+00:00"
+            "time": "2023-09-26T12:28:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.28",
+            "version": "9.2.29",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7134a5ccaaf0f1c92a4f5501a6c9f98ac4dcc0ef"
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7134a5ccaaf0f1c92a4f5501a6c9f98ac4dcc0ef",
-                "reference": "7134a5ccaaf0f1c92a4f5501a6c9f98ac4dcc0ef",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
                 "shasum": ""
             },
             "require": {
@@ -1796,7 +1796,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.28"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
             },
             "funding": [
                 {
@@ -1804,7 +1804,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-12T14:36:20+00:00"
+            "time": "2023-09-19T04:57:46+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2049,16 +2049,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.12",
+            "version": "9.6.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a122c2ebd469b751d774aa0f613dc0d67697653f"
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a122c2ebd469b751d774aa0f613dc0d67697653f",
-                "reference": "a122c2ebd469b751d774aa0f613dc0d67697653f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
+                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
                 "shasum": ""
             },
             "require": {
@@ -2132,7 +2132,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.12"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
             },
             "funding": [
                 {
@@ -2148,7 +2148,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-12T14:39:31+00:00"
+            "time": "2023-09-19T05:39:22+00:00"
         },
         {
             "name": "psr/container",
@@ -3950,25 +3950,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3997,7 +3997,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4013,7 +4013,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -4176,29 +4176,26 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.0.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051"
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051",
-                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
-            },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4235,7 +4232,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4251,7 +4248,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -5136,32 +5133,33 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.0.19",
+            "version": "v6.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
+                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
-                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "url": "https://api.github.com/repos/symfony/string/zipball/13d76d0fb049051ed12a04bef4f9de8715bea339",
+                "reference": "13d76d0fb049051ed12a04bef4f9de8715bea339",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
-                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/intl": "^6.2",
+                "symfony/translation-contracts": "^2.5|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
@@ -5201,7 +5199,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.0.19"
+                "source": "https://github.com/symfony/string/tree/v6.3.5"
             },
             "funding": [
                 {
@@ -5217,7 +5215,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-01T08:36:10+00:00"
+            "time": "2023-09-18T10:38:32+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5388,20 +5386,21 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.0.19",
+            "version": "v6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "deec3a812a0305a50db8ae689b183f43d915c884"
+                "reference": "e23292e8c07c85b971b44c1c4b87af52133e2add"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/deec3a812a0305a50db8ae689b183f43d915c884",
-                "reference": "deec3a812a0305a50db8ae689b183f43d915c884",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e23292e8c07c85b971b44c1c4b87af52133e2add",
+                "reference": "e23292e8c07c85b971b44c1c4b87af52133e2add",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2",
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -5409,9 +5408,6 @@
             },
             "require-dev": {
                 "symfony/console": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -5442,7 +5438,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.0.19"
+                "source": "https://github.com/symfony/yaml/tree/v6.3.3"
             },
             "funding": [
                 {
@@ -5458,7 +5454,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-11T11:50:03+00:00"
+            "time": "2023-07-31T07:08:24+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5512,16 +5508,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
@@ -5568,7 +5564,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-08-21T14:28:38+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, jspellman, jazzs3quence
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
-Tested up to: 6.3
+Tested up to: 6.3.1
 Stable tag: 0.4.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pantheon HUD ===
-Contributors: getpantheon, danielbachhuber, jspellman, jazzs3quence
+Contributors: getpantheon, danielbachhuber, jazzs3quence
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
 Tested up to: 6.3.1


### PR DESCRIPTION
Our `main` branch is up-to-date with `master`. In our ongoing effort to deprecate `master` generally, I don't see any specific reason not to just switch over to `main` if they are already in sync. However, if we're moving stuff around, probably we should maintain consistency with other plugin repositories that use `main` and `release` rather than `develop` and `main`/`master`.

This PR also adds a few other changes:
* uses Pantheon WP Coding Standards over WPCS (and applies changes required by updated sniffs)
* adds a `phpcbf` script to the `composer.json`
* runs an apply updates on the fixture before tests are run (so we're always using the latest version when running checks)
* removes @jspellman814 from contributors (😭)


**TODO:**
- [x] Create new `release` off `main`
- [x] Create new `main` off `develop`
- [x] Set the default branch to `main` (after rename)
- [x] Apply any branch protection rules that were previously on `master` to `release`
- [x] Apply any branch protection rules that were previously on `develop` to `main` (might be handled by just renaming branches)
- [x] Delete the `master` branch
- [x] Delete the `main` branch
- [x] Delete the `develop` branch

Because we will still have a main branch, pulls from the repository should still work assuming we had a `main` the last time someone pulled and it should be the thing we are expecting (develop, rather than `master`/`release`).