### PR TITLE
set circle badge to main rather than master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
-**Tags:** Pantheon, hosting, environment-indicator
-**Requires at least:** 4.9
-**Tested up to:** 6.3.1
-**Stable tag:** 0.4.4-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
+**Tags:** Pantheon, hosting, environment-indicator  
+**Requires at least:** 4.9  
+**Tested up to:** 6.3.1  
+**Stable tag:** 0.4.4-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
-**Tags:** Pantheon, hosting, environment-indicator  
-**Requires at least:** 4.9  
-**Tested up to:** 6.3.1  
-**Stable tag:** 0.4.4-dev  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
+**Tags:** Pantheon, hosting, environment-indicator
+**Requires at least:** 4.9
+**Tested up to:** 6.3.1
+**Stable tag:** 0.4.4-dev
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.
 
 ## Description ##
 
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/master.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/master)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/pantheon-systems/pantheon-hud/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/pantheon-systems/pantheon-hud/tree/main)
 [![Lint & Test](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support)
 


### PR DESCRIPTION
this existed in an earlier incarnation but likely got swallowed by reverts/merge conflicts when the base branch was changed