### PR TITLE
[cmsp-679] PHP 8.3 compatibility checks

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -29,6 +29,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - uses: pantheon-systems/validate-readme-spacing@v1
+  php8-compatibility:
+    name: PHP 8.x Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: PHP Compatibility
+        uses: pantheon-systems/phpcompatibility-action@dev
+        with:
+          test-versions: 8.0-
+          paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
   test-phpunit-74:
     needs: lint
     runs-on: ubuntu-latest
@@ -80,8 +91,6 @@ jobs:
           restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
       - name: Install Composer dependencies
         run: composer install
-      - name: Run PHP 8.x Compatibility Check
-        run: composer php8-check
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh
   test-phpunit-83:
@@ -108,7 +117,5 @@ jobs:
           restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
       - name: Install Composer dependencies
         run: composer install
-      - name: Run PHP 8.x Compatibility Check
-        run: composer php8-check
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -67,32 +67,6 @@ jobs:
           composer update && composer install
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh
-  test-phpunit-82:
-    needs: lint
-    runs-on: ubuntu-latest
-    services:
-      mariadb:
-        image: mariadb:10.6
-    name: PHP 8.2 Unit Tests
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup PHP 8.2
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.2
-          extensions: mysqli, zip, imagick
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/vendor
-          key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
-          restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
-      - name: Install Composer dependencies
-        run: composer install
-      - name: Run PHPUnit
-        run: bash ./bin/phpunit-test.sh
   test-phpunit-83:
     needs: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -84,3 +84,31 @@ jobs:
         run: composer php8-check
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh
+  test-phpunit-83:
+    needs: lint
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:10.6
+    name: PHP 8.3 Unit Tests
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP 8.3
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: mysqli, zip, imagick
+      - name: Start MySQL Service
+        run: sudo systemctl start mysql
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/vendor
+          key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
+          restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
+      - name: Install Composer dependencies
+        run: composer install
+      - name: Run PHP 8.x Compatibility Check
+        run: composer php8-check
+      - name: Run PHPUnit
+        run: bash ./bin/phpunit-test.sh

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -80,5 +80,7 @@ jobs:
           restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
       - name: Install Composer dependencies
         run: composer install
+      - name: Run PHP 8.x Compatibility Check
+        run: composer php8-check
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Install Composer dependencies
         run: |
           composer update && composer install
+      - name: Run PHP linting
+        run: composer phplint
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh
   test-phpunit-83:
@@ -91,5 +93,7 @@ jobs:
           restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
       - name: Install Composer dependencies
         run: composer install
+      - name: Run PHP linting
+        run: composer phplint
       - name: Run PHPUnit
         run: bash ./bin/phpunit-test.sh

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -13,7 +13,7 @@ if [[ "$1" == "--no-db" ]]; then
 fi
 
 # Run install-wp-tests.sh
-echo "Installing local tests into ${WP_TESTS_DIR}"
+echo "Installing local tests into ${TMPDIR}"
 bash "$(dirname "$0")/install-wp-tests.sh" wordpress_test root '' 127.0.0.1 latest $SKIP_DB
 
 # Run PHPUnit

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Check if TMPDIR is set; if not, default to /tmp
+TMPDIR="/tmp"
+
+# Explicitly set WP_TESTS_DIR based on TMPDIR
+export WP_TESTS_DIR="${TMPDIR}/wordpress-tests-lib"
+export WP_CORE_DIR="${TMPDIR}/wordpress/"
+
+# Initialize a variable to hold the 'true' flag for skipping DB creation
+SKIP_DB=""
+
+# Check if '--no-db' is passed as an argument
+if [[ "$1" == "--no-db" ]]; then
+  SKIP_DB="true"
+fi
+
+# Run install-wp-tests.sh
+echo "Installing local tests into ${WP_TESTS_DIR}"
+bash "$(dirname "$0")/install-wp-tests.sh" wordpress_test root '' 127.0.0.1 latest $SKIP_DB
+
+# Run PHPUnit
+echo "Running PHPUnit"
+composer phpunit --no-cache

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -1,20 +1,60 @@
 #!/bin/bash
 set -e
 
-# Set TMPDIR to /tmp.
+# Initialize variables with default values
 TMPDIR="/tmp"
-
-# Initialize a variable to hold the 'true' flag for skipping DB creation
+DB_NAME="wordpress_test"
+DB_USER="root"
+DB_PASS=""
+DB_HOST="127.0.0.1"
+WP_VERSION="latest"
 SKIP_DB=""
 
-# Check if '--no-db' is passed as an argument
-if [[ "$1" == "--no-db" ]]; then
-  SKIP_DB="true"
-fi
+# Display usage information
+usage() {
+  echo "Usage:"
+  echo "./install-local-tests.sh [--dbname=wordpress_test] [--dbuser=root] [--dbpass=''] [--dbhost=127.0.0.1] [--wpversion=latest] [--no-db]"
+}
+
+# Parse command-line arguments
+for i in "$@"
+do
+case $i in
+    --dbname=*)
+    DB_NAME="${i#*=}"
+    shift
+    ;;
+    --dbuser=*)
+    DB_USER="${i#*=}"
+    shift
+    ;;
+    --dbpass=*)
+    DB_PASS="${i#*=}"
+    shift
+    ;;
+    --dbhost=*)
+    DB_HOST="${i#*=}"
+    shift
+    ;;
+    --wpversion=*)
+    WP_VERSION="${i#*=}"
+    shift
+    ;;
+    --no-db)
+    SKIP_DB="true"
+    shift
+    ;;
+    *)
+    # unknown option
+    usage
+    exit 1
+    ;;
+esac
+done
 
 # Run install-wp-tests.sh
 echo "Installing local tests into ${TMPDIR}"
-bash "$(dirname "$0")/install-wp-tests.sh" wordpress_test root '' 127.0.0.1 latest $SKIP_DB
+bash "$(dirname "$0")/install-wp-tests.sh" "$DB_NAME" "$DB_USER" "$DB_PASS" "$DB_HOST" "$WP_VERSION" "$SKIP_DB"
 
 # Run PHPUnit
 echo "Running PHPUnit"

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -22,4 +22,4 @@ bash "$(dirname "$0")/install-wp-tests.sh" wordpress_test root '' 127.0.0.1 late
 
 # Run PHPUnit
 echo "Running PHPUnit"
-composer phpunit --no-cache
+composer phpunit

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Check if TMPDIR is set; if not, default to /tmp
+# Set TMPDIR to /tmp.
 TMPDIR="/tmp"
 
 # Initialize a variable to hold the 'true' flag for skipping DB creation

--- a/bin/install-local-tests.sh
+++ b/bin/install-local-tests.sh
@@ -4,10 +4,6 @@ set -e
 # Check if TMPDIR is set; if not, default to /tmp
 TMPDIR="/tmp"
 
-# Explicitly set WP_TESTS_DIR based on TMPDIR
-export WP_TESTS_DIR="${TMPDIR}/wordpress-tests-lib"
-export WP_CORE_DIR="${TMPDIR}/wordpress/"
-
 # Initialize a variable to hold the 'true' flag for skipping DB creation
 SKIP_DB=""
 

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -3,6 +3,7 @@
 set -e
 
 DIRNAME=$(dirname "$0")
+
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 echo "Running PHPUnit on Single Site"
 composer phpunit

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -3,7 +3,7 @@
 set -e
 
 DIRNAME=$(dirname "$0")
-
+echo "$WP_TESTS_DIR"
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 echo "Running PHPUnit on Single Site"
 composer phpunit

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -3,7 +3,7 @@
 set -e
 
 DIRNAME=$(dirname "$0")
-echo "$WP_TESTS_DIR"
+echo "Installing tests into ${WP_TESTS_DIR}"
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 echo "Running PHPUnit on Single Site"
 composer phpunit

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -3,7 +3,6 @@
 set -e
 
 DIRNAME=$(dirname "$0")
-echo "Installing tests into ${WP_TESTS_DIR}"
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 echo "Running PHPUnit on Single Site"
 composer phpunit

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,12 @@
     "prefer-stable": true,
     "scripts": {
         "lint": [
-            "@phpcs"
+            "@phpcs",
+            "@phplint"
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
+        "phplint": "find . -type f -name '*.php' -not -path './vendor/*' -not -path './tests/*' -exec php -l {} \\;",
         "phpunit": "phpunit --do-not-cache-result",
         "test": "@phpunit",
         "test:install": "bin/install-local-tests.sh --no-db",

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,7 @@
         "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
         "phpunit/phpunit": "^9",
         "yoast/phpunit-polyfills": "^2.0",
-        "symfony/yaml": "^5.4 || ^6",
-        "phpcompatibility/phpcompatibility-wp": "dev-master as 2.1.0",
-        "phpcompatibility/php-compatibility": "dev-develop as 9.3.5"
+        "symfony/yaml": "^5.4 || ^6"
     },
     "autoload-dev": {
         "psr-4": {
@@ -31,15 +29,11 @@
     "prefer-stable": true,
     "scripts": {
         "lint": [
-            "@phpcs",
-            "@php8-check"
+            "@phpcs"
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
         "phpunit": "phpunit --do-not-cache-result",
-        "php8-check": [
-          "phpcs -p . --standard=PHPCompatibilityWP --ignore=vendor/ --runtime-set testVersion 8.0-"
-        ],
         "test": "@phpunit",
         "test:install": "bin/install-local-tests.sh --no-db",
         "test:install:withdb": "bin/install-local-tests.sh"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
-        "phpunit": "phpunit --no-cache",
+        "phpunit": "phpunit --do-not-cache-result",
         "test": "@phpunit",
         "test:install": "bin/install-local-tests.sh --no-db",
         "test:install:withdb": "bin/install-local-tests.sh"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "yoast/phpunit-polyfills": "^2.0",
         "symfony/yaml": "^5.4 || ^6",
         "phpcompatibility/phpcompatibility-wp": "dev-master as 2.1.0",
-        "phpcompatibility/php-compatibility": "dev-master as 9.3.0"
+        "phpcompatibility/php-compatibility": "dev-develop as 9.3.5"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,9 @@
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
         "phpunit": "phpunit",
-        "test": "@phpunit"
+        "test": "@phpunit",
+        "test:install": "bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest true",
+        "test:install:withdb": "bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
-        "phpunit": "phpunit",
+        "phpunit": "phpunit --no-cache",
         "test": "@phpunit",
-        "test:install": "bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest true",
-        "test:install:withdb": "bash bin/install-wp-tests.sh wordpress_test root '' 127.0.0.1 latest"
+        "test:install": "bin/install-local-tests.sh --no-db",
+        "test:install:withdb": "bin/install-local-tests.sh"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,15 @@
     "prefer-stable": true,
     "scripts": {
         "lint": [
-            "@phpcs"
+            "@phpcs",
+            "@php8-check"
         ],
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
         "phpunit": "phpunit --do-not-cache-result",
+        "php8-check": [
+          "phpcs -p . --standard=PHPCompatibilityWP --ignore=vendor/ --runtime-set testVersion 8.0-"
+        ],
         "test": "@phpunit",
         "test:install": "bin/install-local-tests.sh --no-db",
         "test:install:withdb": "bin/install-local-tests.sh"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,9 @@
         "pantheon-systems/pantheon-wp-coding-standards": "^2.0",
         "phpunit/phpunit": "^9",
         "yoast/phpunit-polyfills": "^2.0",
-        "symfony/yaml": "^5.4 || ^6"
+        "symfony/yaml": "^5.4 || ^6",
+        "phpcompatibility/phpcompatibility-wp": "dev-master as 2.1.0",
+        "phpcompatibility/php-compatibility": "dev-master as 9.3.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc61dbbf770feb3a621a0357a91aa31b",
+    "content-hash": "da76c23260efdd54734d7e37e9fe7ed3",
     "packages": [],
     "packages-dev": [
         {
@@ -1373,33 +1373,45 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "dev-master",
+            "version": "dev-develop",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+                "reference": "302dffedd8f1acfc0ed5c7ee096ea2237553ae1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/302dffedd8f1acfc0ed5c7ee096ea2237553ae1a",
+                "reference": "302dffedd8f1acfc0ed5c7ee096ea2237553ae1a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.1"
             },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
+            "replace": {
+                "wimg/php-compatibility": "*"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.3",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev",
+                    "dev-develop": "10.x-dev"
+                }
+            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
@@ -1425,13 +1437,14 @@
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
-            "time": "2019-12-27T09:44:58+00:00"
+            "time": "2023-09-13T12:40:15+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -5637,9 +5650,9 @@
     "aliases": [
         {
             "package": "phpcompatibility/php-compatibility",
-            "version": "9999999-dev",
-            "alias": "9.3.0",
-            "alias_normalized": "9.3.0.0"
+            "version": "dev-develop",
+            "alias": "9.3.5",
+            "alias_normalized": "9.3.5.0"
         },
         {
             "package": "phpcompatibility/phpcompatibility-wp",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "762aedeb842219cbe0204d08822e130a",
+    "content-hash": "dc61dbbf770feb3a621a0357a91aa31b",
     "packages": [],
     "packages-dev": [
         {
@@ -1373,7 +1373,7 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.5",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
@@ -1492,16 +1492,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+                "reference": "1708fc935ceeff3ec57dca5b1b18666403e53fba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/1708fc935ceeff3ec57dca5b1b18666403e53fba",
+                "reference": "1708fc935ceeff3ec57dca5b1b18666403e53fba",
                 "shasum": ""
             },
             "require": {
@@ -1509,12 +1509,13 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
+            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1543,7 +1544,7 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2022-10-24T09:00:36+00:00"
+            "time": "2023-09-27T11:31:40+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -5633,10 +5634,25 @@
             "time": "2023-06-06T20:28:24+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "phpcompatibility/php-compatibility",
+            "version": "9999999-dev",
+            "alias": "9.3.0",
+            "alias_normalized": "9.3.0.0"
+        },
+        {
+            "package": "phpcompatibility/phpcompatibility-wp",
+            "version": "9999999-dev",
+            "alias": "2.1.0",
+            "alias_normalized": "2.1.0.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
-        "pantheon-systems/pantheon-wordpress-upstream-tests": 20
+        "pantheon-systems/pantheon-wordpress-upstream-tests": 20,
+        "phpcompatibility/phpcompatibility-wp": 20,
+        "phpcompatibility/php-compatibility": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "da76c23260efdd54734d7e37e9fe7ed3",
+    "content-hash": "495907a95f131d852721af5a9bdc4055",
     "packages": [],
     "packages-dev": [
         {
@@ -1373,45 +1373,33 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "dev-develop",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "302dffedd8f1acfc0ed5c7ee096ea2237553ae1a"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/302dffedd8f1acfc0ed5c7ee096ea2237553ae1a",
-                "reference": "302dffedd8f1acfc0ed5c7ee096ea2237553ae1a",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.5",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
             },
-            "replace": {
-                "wimg/php-compatibility": "*"
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
             },
             "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.3",
-                "phpcsstandards/phpcsdevtools": "^1.2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4 || ^10.1.0",
-                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.x-dev",
-                    "dev-develop": "10.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-3.0-or-later"
@@ -1437,14 +1425,13 @@
             "keywords": [
                 "compatibility",
                 "phpcs",
-                "standards",
-                "static analysis"
+                "standards"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
-            "time": "2023-09-13T12:40:15+00:00"
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
@@ -1505,16 +1492,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "dev-master",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "1708fc935ceeff3ec57dca5b1b18666403e53fba"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/1708fc935ceeff3ec57dca5b1b18666403e53fba",
-                "reference": "1708fc935ceeff3ec57dca5b1b18666403e53fba",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -1522,13 +1509,12 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
-            "default-branch": true,
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1557,7 +1543,7 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2023-09-27T11:31:40+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
             "name": "phpcsstandards/phpcsextra",
@@ -5647,25 +5633,10 @@
             "time": "2023-06-06T20:28:24+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "phpcompatibility/php-compatibility",
-            "version": "dev-develop",
-            "alias": "9.3.5",
-            "alias_normalized": "9.3.5.0"
-        },
-        {
-            "package": "phpcompatibility/phpcompatibility-wp",
-            "version": "9999999-dev",
-            "alias": "2.1.0",
-            "alias_normalized": "2.1.0.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "pantheon-systems/pantheon-wordpress-upstream-tests": 20,
-        "phpcompatibility/phpcompatibility-wp": 20,
-        "phpcompatibility/php-compatibility": 20
+        "pantheon-systems/pantheon-wordpress-upstream-tests": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
This PR adds PHP8.3 testing. 

As part of the investigation of this PR, I looked into using [PHPStan](https://github.com/phpstan/phpstan) (and the [PHPStan-WordPress](https://github.com/szepeviktor/phpstan-wordpress) extension) but found that those are more general purpose, code style checks that may or may not provide any insight into PHP 8+ compatibility.

It uses the [`phpcompatibility-action`](https://github.com/pantheon-systems/phpcompatibility-action/) to check PHPCompatibility as a new GH action. (PHPCompatibility-WP is part of Pantheon WP Coding Standards but PHPCompatibility does not support 8.x on the stable branch).

The version of PHP that is used when running the PHP Unit tests has also been updated to PHP 8.3 rather than 8.2. Anything that would be an issue with earlier versions of PHP 8.x would still be an issue in 8.3 so there's no benefit to running PHP Unit in both 8.2 _and_ 8.3.

The Behat tests are still running on a PHP 8.2 container. We would need a new build tools image in Quay that used PHP 8.3, so this change will need to wait until that image exists.

This PR also adds a new script for setting up PHPUnit locally which resolves the file not found error when it's looking for `wordpress-test-libs` in the wrong location.