### PR TITLE
add john back as contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)    
 **Tags:** Pantheon, hosting, environment-indicator  
 **Requires at least:** 4.9  
 **Tested up to:** 6.3.1  

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pantheon HUD ===
-Contributors: getpantheon, danielbachhuber, jazzs3quence
+Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
 Tested up to: 6.3.1


### PR DESCRIPTION
contributors don't have commit access, only listed committers in the plugin's Advanced view, see https://developer.wordpress.org/plugins/wordpress-org/special-user-roles-capabilities/#committer

Re-adding @jspellman

https://github.com/pantheon-systems/pantheon-hud/pull/133#issuecomment-1749501927