### PR TITLE
[CMSP-721] Ensure that Behat tests run on PHP 8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
-**Tags:** Pantheon, hosting, environment-indicator
-**Requires at least:** 4.9
-**Tested up to:** 6.4.1
-**Stable tag:** 0.4.4-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
+**Tags:** Pantheon, hosting, environment-indicator  
+**Requires at least:** 4.9  
+**Tested up to:** 6.4.1  
+**Stable tag:** 0.4.4-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)    
-**Tags:** Pantheon, hosting, environment-indicator  
-**Requires at least:** 4.9  
-**Tested up to:** 6.3.1  
-**Stable tag:** 0.4.4-dev  
-**License:** GPLv2 or later  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
+**Tags:** Pantheon, hosting, environment-indicator
+**Requires at least:** 4.9
+**Tested up to:** 6.4.1
+**Stable tag:** 0.4.4-dev
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -50,6 +50,9 @@ PANTHEON_SITE_URL="$TERMINUS_ENV-$TERMINUS_SITE.pantheonsite.io"
 PREPARE_DIR="/tmp/$TERMINUS_ENV-$TERMINUS_SITE"
 BASH_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+PHP_VERSION="$(terminus connection:info $SITE_ENV --field=php_version)"
+echo "PHP Version: $PHP_VERSION"
+
 ###
 # Switch to git mode for pushing the files up
 ###

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -50,7 +50,7 @@ PANTHEON_SITE_URL="$TERMINUS_ENV-$TERMINUS_SITE.pantheonsite.io"
 PREPARE_DIR="/tmp/$TERMINUS_ENV-$TERMINUS_SITE"
 BASH_DIR="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-PHP_VERSION="$(terminus connection:info $SITE_ENV --field=php_version)"
+PHP_VERSION="$(terminus env:info $SITE_ENV --field=php_version)"
 echo "PHP Version: $PHP_VERSION"
 
 ###

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -39,8 +39,8 @@ fi
 ###
 # Create a new environment for this particular test run.
 ###
-terminus env:create  $TERMINUS_SITE.dev $TERMINUS_ENV
-terminus env:wipe $SITE_ENV --yes
+terminus env:create "${TERMINUS_SITE}.dev" "$TERMINUS_ENV"
+terminus env:wipe "$SITE_ENV" --yes
 
 ###
 # Get all necessary environment details.

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -30,7 +30,7 @@ main(){
     echo "Tested Up To: ${TESTED_UP_TO}"
     local FIXTURE_VERSION
     # Ignore NewRelic error.
-    FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version 2>&1 | grep -v "PHP Startup: Unable to load dynamic library" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+)?$/ {print $0; exit}')
+    FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
     echo "Fixture Version: ${FIXTURE_VERSION}"
 
     compare_result=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}');")

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -29,7 +29,8 @@ main(){
     TESTED_UP_TO=$(grep -i "Tested up to:" "${README_FILE_PATH}" | tr -d '\r\n' | awk -F ': ' '{ print $2 }')
     echo "Tested Up To: ${TESTED_UP_TO}"
     local FIXTURE_VERSION
-    FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
+    # Ignore NewRelic error.
+    FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version 2>&1 | grep -v "PHP Startup: Unable to load dynamic library" | awk '/^[0-9]+\.[0-9]+(\.[0-9]+)?$/ {print $0; exit}')
     echo "Fixture Version: ${FIXTURE_VERSION}"
 
     compare_result=$(php -r "echo version_compare('${TESTED_UP_TO}', '${FIXTURE_VERSION}');")

--- a/bin/validate-fixture-version.sh
+++ b/bin/validate-fixture-version.sh
@@ -29,7 +29,6 @@ main(){
     TESTED_UP_TO=$(grep -i "Tested up to:" "${README_FILE_PATH}" | tr -d '\r\n' | awk -F ': ' '{ print $2 }')
     echo "Tested Up To: ${TESTED_UP_TO}"
     local FIXTURE_VERSION
-    # Ignore NewRelic error.
     FIXTURE_VERSION=$(terminus wp "${TERMINUS_SITE}.dev" -- core version)
     echo "Fixture Version: ${FIXTURE_VERSION}"
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
-Tested up to: 6.3.1
+Tested up to: 6.4.1
 Stable tag: 0.4.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Applies most of the same changes in https://github.com/pantheon-systems/wp-native-php-sessions/pull/283 in order to ensure that Behat runs on PHP 8.3. Most notably:

* bumps the tested up to version
* ~~applies the fix to ignore the newrelic error for validating the tested up to version~~ fixed in https://github.com/pantheon-systems/infrastructure/pull/3574
* outputs the PHP version during `behat-prepare.sh`

The fixture site is already using PHP 8.3 and was updated with the latest (6.4.1) WP version.