### PR TITLE
Add display:inline to pantheon logo in admin bar item

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -192,6 +192,7 @@ EOT;
 				width:32px;
 				vertical-align:middle;
 				margin-top:-4px;
+				display:inline;
 			}
 			#wpadminbar li#wp-admin-bar-pantheon-hud em {
 				font-size: 11px;


### PR DESCRIPTION
The Twenty Twenty theme includes these styles:

```css
svg,
img,
embed,
object {
	display: block;
	height: auto;
	max-width: 100%;
}
```

This breaks the Pantheon logo in the HUD:

> ![Screenshot 2024-11-21 13 28 06](https://github.com/user-attachments/assets/8bd5c656-da9a-47ea-b08a-4d25df941102)

The `display:inline` style needs to be added to the existing style rule with the `#wpadminbar li#wp-admin-bar-pantheon-hud > .ab-item` selector to fix this. With the change:

> ![Screenshot 2024-11-21 13 28 15](https://github.com/user-attachments/assets/91cb976c-7b70-4e52-9391-2c57c137393f)

Note that `display:inline` is the style that the `IMG` has in the admin, not `display:inline-block`.