### PR TITLE
add jazzsequence/action-validate-plugin-version

### DIFF
--- a/.github/workflows/tested-up-to.yml
+++ b/.github/workflows/tested-up-to.yml
@@ -1,0 +1,18 @@
+name: Validate Plugin "Tested Up To" Version
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  validate-wp-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Plugin Tested Up To Version
+        uses: jazzsequence/action-validate-plugin-version@v1
+        with:
+          filenames: 'readme.txt,README.md'
+          branch: 'main'

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
-**Tags:** Pantheon, hosting, environment-indicator  
-**Requires at least:** 4.9  
-**Tested up to:** 6.4.1  
-**Stable tag:** 0.4.4-dev  
-**License:** GPLv2 or later  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
+**Tags:** Pantheon, hosting, environment-indicator
+**Requires at least:** 4.9
+**Tested up to:** 6.7.1
+**Stable tag:** 0.4.4-dev
+**License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)
-**Tags:** Pantheon, hosting, environment-indicator
-**Requires at least:** 4.9
-**Tested up to:** 6.7.1
-**Stable tag:** 0.4.4-dev
-**License:** GPLv2 or later
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence)  
+**Tags:** Pantheon, hosting, environment-indicator  
+**Requires at least:** 4.9  
+**Tested up to:** 6.7.1  
+**Stable tag:** 0.4.4-dev  
+**License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 A heads-up display into your Pantheon environment.

--- a/composer.lock
+++ b/composer.lock
@@ -1192,13 +1192,13 @@
             "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "git@github.com:pantheon-systems/pantheon-wordpress-upstream-tests.git",
-                "reference": "004fc97a604950aef4f62773417691d23b3d75b0"
+                "url": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests.git",
+                "reference": "1fa393d4d65a888cbd5f11a405827e9695fb0634"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/pantheon-wordpress-upstream-tests/zipball/004fc97a604950aef4f62773417691d23b3d75b0",
-                "reference": "004fc97a604950aef4f62773417691d23b3d75b0",
+                "url": "https://api.github.com/repos/pantheon-systems/pantheon-wordpress-upstream-tests/zipball/1fa393d4d65a888cbd5f11a405827e9695fb0634",
+                "reference": "1fa393d4d65a888cbd5f11a405827e9695fb0634",
                 "shasum": ""
             },
             "require": {
@@ -1220,7 +1220,11 @@
                     "email": "noreply@pantheon.io"
                 }
             ],
-            "time": "2023-08-11T17:05:44+00:00"
+            "support": {
+                "issues": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/issues",
+                "source": "https://github.com/pantheon-systems/pantheon-wordpress-upstream-tests/tree/master"
+            },
+            "time": "2024-09-23T20:47:25+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wp-coding-standards",
@@ -5642,5 +5646,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
-Tested up to: 6.4.1
+Tested up to: 6.7.1
 Stable tag: 0.4.4-dev
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Adds [`jazzsequence/action-validate-plugin-version`](https://github.com/jazzsequence/action-validate-plugin-version) to regularly check the tested-up-to version