### PR TITLE
DELENG-424: Update Site ownership to site-experience

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: library
   lifecycle: mature
-  owner: site
+  owner: site-experience


### PR DESCRIPTION
## Summary
- Update catalog-info.yaml owner from 'site' to 'site-experience'

## Context
Resolving ownership inconsistency:
- catalog-info.yaml: `owner: site`
- CODEOWNERS: `@pantheon-systems/site-experience` (no changes needed)
- pan-owner: N/A (repo not managed in github-terraform)

Part of [DELENG-424](https://getpantheon.atlassian.net/browse/DELENG-424) - Resolve ownership inconsistencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DELENG-424]: https://getpantheon.atlassian.net/browse/DELENG-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ