### PR TITLE
ci: Fix behat workflow triggers, security, and caching

### DIFF
--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -1,6 +1,9 @@
 name: Test Behat CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
   # Nightly at 00:00 UTC
@@ -9,8 +12,6 @@ on:
 
 jobs:
   test-behat:
-    # Skip scheduled runs unless the workflow file is on a branch named 'release'
-    if: github.event_name != 'schedule' || github.ref_name == 'release'
     runs-on: ubuntu-latest
 
     defaults:
@@ -23,12 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: '8.4'
           tools: composer
@@ -36,11 +35,11 @@ jobs:
           extensions: mbstring, intl, zip
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ~/vendor
-          key: test-lint-dependencies-${{ hashFiles('composer.json') }}
-          restore-keys: test-lint-dependencies-${{ hashFiles('composer.json') }}
+          path: vendor
+          key: composer-deps-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-deps-
 
       - name: Generate WP admin password
         run: echo "$(openssl rand -hex 8)" > /tmp/WORDPRESS_ADMIN_PASSWORD
@@ -59,7 +58,7 @@ jobs:
         run: echo "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" >> $GITHUB_ENV
 
       - name: Install SSH key
-        uses: webfactory/ssh-agent@v0.7.0
+        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
         with:
           ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
 
@@ -73,12 +72,13 @@ jobs:
           { composer config -g github-oauth.github.com "${GITHUB_TOKEN}"; } &>/dev/null
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@v1
+        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 
       - name: Validate WordPress 'Tested Up To' version
-        uses: jazzsequence/action-validate-plugin-version@v1
+        if: github.event_name == 'pull_request'
+        uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1
         with:
           branch: ${{ github.head_ref }}
           dry-run: 'true'

--- a/bin/behat-prepare.sh
+++ b/bin/behat-prepare.sh
@@ -101,9 +101,11 @@ terminus wp $SITE_ENV -- core update --force || echo "WordPress core update fail
 ###
 
 # Retry WP core install as the environment may take a moment to be ready.
+# Silence output so as not to show the password.
 max_attempts=5
 attempt_num=1
-until terminus wp $SITE_ENV -- core install --title=$TERMINUS_ENV-$TERMINUS_SITE --url=$PANTHEON_SITE_URL --admin_user=$WORDPRESS_ADMIN_USERNAME --admin_email=pantheon-hud@getpantheon.com --admin_password=$WORDPRESS_ADMIN_PASSWORD; do
+set +x
+until terminus wp $SITE_ENV -- core install --title=$TERMINUS_ENV-$TERMINUS_SITE --url=$PANTHEON_SITE_URL --admin_user=$WORDPRESS_ADMIN_USERNAME --admin_email=pantheon-hud@getpantheon.com --admin_password=$WORDPRESS_ADMIN_PASSWORD &>/dev/null; do
   if [ $attempt_num -eq $max_attempts ]; then
     echo "WP core install failed after $max_attempts attempts."
     exit 1
@@ -112,6 +114,7 @@ until terminus wp $SITE_ENV -- core install --title=$TERMINUS_ENV-$TERMINUS_SITE
   sleep 15
   attempt_num=$((attempt_num+1))
 done
+set -x
 
 terminus wp $SITE_ENV -- cache flush
 terminus wp $SITE_ENV -- plugin activate pantheon-hud


### PR DESCRIPTION
## Summary

Fixes issues introduced in the CircleCI-to-GHA migration (#175).

- Add `push: main` trigger and remove broken schedule filter — nightly and post-merge tests were not running
- SHA-pin all actions, bump checkout to v6.0.2 and cache to v5.0.4
- Fix cache path (`~/vendor` → `vendor`) and key (`composer.json` → `composer.lock`)
- Suppress admin password from CI logs in behat-prepare.sh
- Skip `validate-plugin-version` on schedule/dispatch (empty `github.head_ref`), bump to v2.0.1
- Remove unnecessary `fetch-depth: 0`

CircleCI tested every push to every branch. GHA tests PRs + push to main only — this covers the same real-world scenarios since feature branches without PRs aren't a workflow used on this repo.

## Test plan

- [ ] PR triggers behat workflow
- [ ] Nightly schedule runs on main (verify after merge)
- [ ] Admin password not visible in CI logs