### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ The `release` branch matches the latest stable release deployed to [wp.org](wp.o
 
 You may notice there are three sets of tests running:
 
-* [PHPCS](https://github.com/squizlabs/PHP_CodeSniffer) to detect violations of [Pantheon WP Coding Standards](https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards).
+* [PHPCS](https://github.com/PHPCSStandards/PHP_CodeSniffer) to detect violations of [Pantheon WP Coding Standards](https://github.com/pantheon-systems/Pantheon-WP-Coding-Standards).
 * [PHPUnit](https://phpunit.de/) test suite.
 * [Behat](http://behat.org/) test suite against a Pantheon site, to ensure the plugin's compatibility with the Pantheon platform.
 


### PR DESCRIPTION
Alternative to #196 

Cherry-picked to sign and run CI from branch instead of fork.

> PHP_CodeSniffer has moved to a new GitHub organization. The squizlabs/PHP_CodeSniffer repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.
> See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932