### PR TITLE
ci: [SITE-5204] test PHP 8.5 compatibility

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,19 +47,23 @@ jobs:
         with:
           test-versions: 8.0-
           paths: ${{ github.workspace }}/*.php ${{ github.workspace }}/inc/*.php
-  test-phpunit-74:
+  test-phpunit:
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.4', '8.4', '8.5']
     services:
       mariadb:
-        image: mariadb:10.5
-    name: PHP 7.4 Unit Tests
+        image: ${{ matrix.php-version == '7.4' && 'mariadb:10.5' || 'mariadb:10.6' }}
+    name: PHP ${{ matrix.php-version }} Unit Tests
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup PHP 7.4
+      - name: Setup PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php-version }}
           extensions: mysqli, zip, imagick
       - name: Start MySQL Service
         run: sudo systemctl start mysql
@@ -67,58 +71,16 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/vendor
-          key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
-          restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
+          key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}-${{ matrix.php-version }}
+          restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}-${{ matrix.php-version }}
       - name: Setup WP-CLI
         uses: godaddy-wordpress/setup-wp-cli@80c9a89bd347082429795c0f12acf567e2c390d4 # 1 2022-10-04T19:52:20Z
       - name: Install Composer dependencies
         run: |
-          composer require pantheon-systems/pantheon-wp-coding-standards:^2.0 --dev --no-update
-          composer update
-          composer install
-          chmod +x bin/*.sh
-      - name: Run PHP linting
-        run: composer phplint
-      - name: Reset MariaDB root password to empty
-        run: |
-          until mysqladmin ping -h127.0.0.1 -uroot -proot --silent; do
-            sleep 1
-          done
-          mysql -h127.0.0.1 -uroot -proot <<'SQL'
-            ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';
-            FLUSH PRIVILEGES;
-          SQL
-          mysqladmin ping -h127.0.0.1 -uroot --silent
-      - name: Install WPUnit tests
-        run: composer test:install:withdb
-      - name: Run PHPUnit
-        run: composer phpunit
-  test-phpunit-84:
-    needs: lint
-    runs-on: ubuntu-latest
-    services:
-      mariadb:
-        image: mariadb:10.6
-    name: PHP 8.4 Unit Tests
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Setup PHP 8.4
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
-        with:
-          php-version: 8.4
-          extensions: mysqli, zip, imagick
-      - name: Start MySQL Service
-        run: sudo systemctl start mysql
-      - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/vendor
-          key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
-          restore-keys: test-phpunit-dependencies-${{ hashFiles('composer.json') }}
-      - name: Setup WP-CLI
-        uses: godaddy-wordpress/setup-wp-cli@80c9a89bd347082429795c0f12acf567e2c390d4 # 1 2022-10-04T19:52:20Z
-      - name: Install Composer dependencies
-        run: |
+          if [ "${{ matrix.php-version }}" = "7.4" ]; then
+            composer require pantheon-systems/pantheon-wp-coding-standards:^2.0 --dev --no-update
+            composer update
+          fi
           composer install
           chmod +x bin/*.sh
       - name: Run PHP linting

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: composer
           coverage: none
           extensions: mbstring, intl, zip

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install SSH key
         uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
         with:
-          ssh-private-key: ${{ secrets.SITE_OWNER_SSH_PRIVATE_KEY }}
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Configure Composer GitHub OAuth (optional)
         env:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Pantheon HUD #
-**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence), [pwtyler](https://profiles.wordpress.org/pwtyler)  
+**Contributors:** [getpantheon](https://profiles.wordpress.org/getpantheon/), [danielbachhuber](https://profiles.wordpress.org/danielbachhuber/), [jspellman](https://profiles.wordpress.org/jspellman/), [jazzs3quence](https://profiles.wordpress.org/jazzs3quence), [pwtyler](https://profiles.wordpress.org/pwtyler), [metasim](https://profiles.wordpress.org/metasim/)  
 **Tags:** Pantheon, hosting, environment-indicator  
 **Requires at least:** 4.9  
 **Tested up to:** 6.9  
@@ -52,7 +52,7 @@ By default, the Pantheon HUD shows dev, test and live. You can modify these valu
 
 ## Changelog ##
 ### 0.4.6-dev ###
-* Supports PHP 8.5
+* Supports PHP 8.5 [[#219](https://github.com/pantheon-systems/pantheon-hud/pull/219)]
 
 ### 0.4.5 ###
 * Supports PHP 8.4 [[#153](https://github.com/pantheon-systems/pantheon-hud/pull/153/)]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ By default, the Pantheon HUD shows dev, test and live. You can modify these valu
 
 ## Changelog ##
 ### 0.4.6-dev ###
+* Supports PHP 8.5
 
 ### 0.4.5 ###
 * Supports PHP 8.4 [[#153](https://github.com/pantheon-systems/pantheon-hud/pull/153/)]

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ By default, the Pantheon HUD appears for logged-in users with the `manage_option
 
 == Changelog ==
 = 0.4.6-dev =
+* Supports PHP 8.5
 
 = 0.4.5 =
 * Supports PHP 8.4 [[#153](https://github.com/pantheon-systems/pantheon-hud/pull/153/)]

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Pantheon HUD ===
-Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman, pwtyler
+Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman, pwtyler, metasim
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
 Tested up to: 6.9
@@ -36,7 +36,7 @@ By default, the Pantheon HUD appears for logged-in users with the `manage_option
 
 == Changelog ==
 = 0.4.6-dev =
-* Supports PHP 8.5
+* Supports PHP 8.5 [[#219](https://github.com/pantheon-systems/pantheon-hud/pull/219)]
 
 = 0.4.5 =
 * Supports PHP 8.4 [[#153](https://github.com/pantheon-systems/pantheon-hud/pull/153/)]


### PR DESCRIPTION
## Summary

- Collapse the three `test-phpunit` jobs into one matrix (7.4, 8.4, 8.5); derive the mariadb image inline (7.4 -> 10.5, others -> 10.6); keep the 7.4-only coding-standards `^2.0` downgrade
- Bump the behat runner to PHP 8.5
- Point the behat SSH step at the rotated `SSH_PRIVATE_KEY` secret (was `SITE_OWNER_SSH_PRIVATE_KEY`)
- Note PHP 8.5 support in README.md + readme.txt changelogs (linked to this PR), and add `metasim` to the Contributors list

## Context

[SITE-5204](https://getpantheon.atlassian.net/browse/SITE-5204)

Last WordPress entry in the PHP 8.5 compatibility initiative (Epic SITE-5195). A PHPCompatibility v10 scan of the shipped source found zero PHP 8.5 deprecations, so no plugin code changed. This PR is CI coverage plus changelog only. Paired test ticket: SITE-5506.

## Test plan

- [x] PHPUnit passes on PHP 8.5 (and 7.4, 8.4 still green)
- [x] Behat passes on PHP 8.5
- [ ] WP.org plugin validation: known pre-existing failure (`wp-env` "Environment not initialized"). Not a required check, fails nightly on main, tracked separately. Out of scope for this PR.

## References

- Jira: [SITE-5204](https://getpantheon.atlassian.net/browse/SITE-5204)


[SITE-5204]: https://getpantheon.atlassian.net/browse/SITE-5204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5204]: https://getpantheon.atlassian.net/browse/SITE-5204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ