### PR TITLE
[SITE-6002] Fix CodeQL alerts

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
   pull_request:
+permissions:
+  contents: read
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -2,6 +2,8 @@ name: Release pantheon-hud plugin to wp.org
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

All 6 open CodeQL alerts flag missing workflow permissions (the "actions/checkout Action depends on a workflow with wide default permissions" finding). Workflows without an explicit `permissions:` block inherit the repository's default token permissions, which is overly broad.

- **`lint-test.yml`** (5 alerts, one per job): Added top-level `permissions: contents: read`. All 5 jobs (lint, wporg-validation, validate-readme-spacing, php8-compatibility, test-phpunit) only checkout code and run read-only operations (linting, tests, compatibility checks).
- **`wordpress-plugin-deploy.yml`** (1 alert): Added top-level `permissions: contents: read`. The deploy action uses SVN credentials from secrets, not the GitHub token, so only read access is needed for checkout.

The other 4 workflows already had explicit permissions blocks and were not flagged.