### PR TITLE
fix(VUL-24446): bump brace-expansion from 1.1.11 to 1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pantheon-hud",
       "version": "0.4.6-dev",
       "devDependencies": {
         "grunt": "^1.6.2",
@@ -79,10 +80,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `brace-expansion` from `1.1.11` to `1.1.16` in `package-lock.json` to address CVE-2026-13149.

Jira ticket: [VUL-24446](https://getpantheon.atlassian.net/browse/VUL-24446)

## CVE Table

| Package | CVE | Severity | Description | Fixed In |
|---------|-----|----------|-------------|----------|
| brace-expansion | [CVE-2026-13149](https://nvd.nist.gov/vuln/detail/CVE-2026-13149) | High | DoS via exponential-time O(2ⁿ) expansion of consecutive non-expanding `{}` groups — a ~90-byte input can stall the Node.js event loop for minutes | 1.1.16 |

## Changes

`brace-expansion` is a **transitive** dependency pulled in by `minimatch ^1.1.7`, which is in turn a dependency of `grunt`. It is a `devDependency` only. The `package-lock.json` is updated to pin `brace-expansion` to `1.1.16`; no changes to `package.json` were required.

The `1.x` branch of `brace-expansion` was vulnerable (`< 1.1.16`). The `minimatch` version constraint (`^1.1.7`) already allows `1.1.16`, so no manifest change is needed — only the lockfile is updated.

[VUL-24446]: https://getpantheon.atlassian.net/browse/VUL-24446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ