### PR TITLE
fix(SITE-5995): bump Tested up to 7.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman, pwtyler, metasim
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 0.4.6-dev
 License: GPLv2 or later


### PR DESCRIPTION
## Summary

- Bump `Tested up to: 6.9` → `7.0` in `readme.txt`

## Context

[SITE-5995](https://getpantheon.atlassian.net/browse/SITE-5995)

plugin-check surfaces `outdated_tested_upto_header` ERROR when `Tested up to` is below the current WP version (7.0). This is the only compliance error in this repo.

## Test plan

- [x] Validate Plugin CI passes with zero ERRORs

[SITE-5995]: https://getpantheon.atlassian.net/browse/SITE-5995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ