### PR TITLE
fix(VUL-25645): bump js-yaml from 3.14.2 to 3.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pantheon-hud",
       "version": "0.4.6-dev",
       "devDependencies": {
         "grunt": "^1.6.2",
@@ -715,9 +716,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "readme": "grunt readme"
   },
+  "overrides": {
+    "js-yaml": "3.15.0"
+  },
   "devDependencies": {
     "grunt": "^1.6.2",
     "grunt-wp-readme-to-markdown": "^2"


### PR DESCRIPTION
## Summary

Bumps the transitive dependency `js-yaml` from 3.14.2 to 3.15.0 to address CVE-2026-59869.

Addresses: [VUL-25645](https://getpantheon.atlassian.net/browse/VUL-25645)

## CVE table

| Package | CVE | Severity | Description | Fixed in |
|---------|-----|----------|-------------|----------|
| [js-yaml](https://www.npmjs.com/package/js-yaml) | [CVE-2026-59869](https://nvd.nist.gov/vuln/detail/CVE-2026-59869) | High | YAML merge-key chains can force quadratic CPU consumption (CWE-400, CWE-407) | 3.15.0 |

## Changes

`js-yaml` is a transitive dependency of `grunt` (which pins `~3.14.0`). Since grunt's own pinning prevents a simple lockfile-only upgrade to 3.15.0, an `overrides` field has been added to `package.json` to force resolution to the patched version. The lockfile (`package-lock.json`) has been regenerated to reflect this.

**Direct dependency?** No — `js-yaml` is only in the lockfile as a transitive dep of `grunt`. The `overrides` approach avoids incorrectly promoting it to a direct dependency while still reaching the patched version.

## CVE attribution analysis

The GHSA advisory confirms this vulnerability is in `js-yaml >= 3.0.0, < 3.15.0`. The repo's installed version is 3.14.2. The project's own Gruntfile does not use YAML directly — `grunt` uses `js-yaml` internally for task loading. The Gruntfile itself is only a dev-time build tool, so exploitability in a production context is essentially nil.

## Risk assessment

**Low** — the bumped package is lockfile-only (transitive dep of a dev-only build tool), and the project's own code does not import js-yaml or call grunt at runtime. No application code path exercises this package in production.

| Layer | Score | Evidence |
|---|---|---|
| Pre-merge detection | partial | PHP lint + PHPUnit on PRs; no JS tests |
| Deployment safety | unknown | No deploy config visible in repo |
| Production detection | unknown | No healthcheck/metrics/alerting config in repo |
| Recovery speed | weak | ~1 release/year; no automated release tooling |

Bump: `js-yaml` 3.14.2 → 3.15.0 (patch). Short-circuit applied: lockfile-only transitive dep of a dev tool; repo code does not import it → **Low** risk regardless of maturity rating.


[VUL-25645]: https://getpantheon.atlassian.net/browse/VUL-25645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ