### PR TITLE
fix(deps): [VUL-24446 et al] npm security bumps + guzzle/psr7 audit-ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,12 @@
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "pantheon-systems/wpunit-helpers": true
+        },
+        "audit": {
+            "ignore": {
+                "GHSA-g446-98w2-8p5w": "Dev-only: guzzlehttp/guzzle 6.5.8 via behat test deps (no 6.x patch line exists). No prod exposure. VUL-24498.",
+                "GHSA-c2w2-prh8-qm98": "Dev-only: guzzlehttp/psr7 1.9.1 via behat test deps (no 1.x patch line exists). No prod exposure. VUL-25209."
+            }
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "pantheon-hud",
       "version": "0.4.6-dev",
       "devDependencies": {
         "grunt": "^1.6.2",
@@ -79,10 +80,11 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -715,9 +717,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "devDependencies": {
     "grunt": "^1.6.2",
     "grunt-wp-readme-to-markdown": "^2"
+  },
+  "overrides": {
+    "js-yaml": "^3.15.0"
   }
 }


### PR DESCRIPTION
## Summary

| Package | Type | Was | Now | Advisory | Route |
|---|---|---|---|---|---|
| brace-expansion | npm (transitive dev) | 1.1.11 | 1.1.17 | GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 | Real bump (lockfile + targeted update) |
| js-yaml | npm (transitive dev) | 3.14.2 | 3.15.0 | GHSA-52cp-r559-cp3m / CVE-2026-59869 | Real bump (lockfile + bounded override) |
| guzzlehttp/guzzle | composer (dev-only) | 6.5.8 | 6.5.8 (no 6.x patch) | GHSA-g446-98w2-8p5w / CVE-2026-59883 | audit-ignore |
| guzzlehttp/psr7 | composer (dev-only) | 1.9.1 | 1.9.1 (no 1.x patch) | GHSA-c2w2-prh8-qm98 / CVE-2026-59882 | audit-ignore |

## Context

- [VUL-24446](https://getpantheon.atlassian.net/browse/VUL-24446) - brace-expansion high (CVE-2026-13149)
- [VUL-24498](https://getpantheon.atlassian.net/browse/VUL-24498) - guzzlehttp/guzzle medium (CVE-2026-59883)
- [VUL-25209](https://getpantheon.atlassian.net/browse/VUL-25209) - guzzlehttp/psr7 medium (CVE-2026-59882)
- [VUL-25645](https://getpantheon.atlassian.net/browse/VUL-25645) - js-yaml high (CVE-2026-59869)

All four tickets target `pantheon-systems/pantheon-hud`. Samwise has separate per-ticket PRs open (#229, #232, #233); this is a consolidated branch that also addresses VUL-24498 (guzzle), which samwise has not touched.

**Prior samwise PRs (open, not merged):**
- PR #229: brace-expansion 1.1.11 -> 1.1.16 (VUL-24446)
- PR #232: psr7 - removes guzzle stack by pinning upstream test driver to a fix branch (VUL-25209)
- PR #233: js-yaml 3.14.2 -> 3.15.0 via overrides (VUL-25645)

This branch takes a different route for psr7/guzzle: audit-ignore instead of upstream driver swap, on the basis that both packages are dev-only with no patch available in their installed major line.

## Advisory Range Analysis

**brace-expansion (GHSA-3jxr-9vmj-r5cp / CVE-2026-13149):**
Three separate ranges in one advisory: `< 1.1.16` (floor 1.1.16), `>= 2.0.0, < 2.1.2` (floor 2.1.2), `>= 3.0.0, < 5.0.7` (floor 5.0.7). Only the 1.x range applies here. Floor met: 1.1.17 >= 1.1.16.

Note: A separate advisory GHSA-mh99-v99m-4gvg (CVE-2026-14257, range `<= 5.0.7`, floor 5.0.8) is flagged by npm audit but is NOT part of VUL-24446. It has no 1.x fix; it would require a 1.x to 5.x major jump. Out of scope for this batch.

**js-yaml (GHSA-52cp-r559-cp3m / CVE-2026-59869):**
Two ranges: `>= 3.0.0, < 3.15.0` (floor 3.15.0) and `>= 4.0.0, < 4.3.0` (floor 4.3.0). Installed version is 3.x; floor met: 3.15.0 >= 3.15.0.

grunt pins `js-yaml: ~3.14.0` which caps at `< 3.15.0`. The declared range blocks the patched floor, so an `overrides` entry is added to package.json, bounded to `^3.15.0` (stays within 3.x). The override is not unbounded.

**guzzlehttp/guzzle (GHSA-g446-98w2-8p5w / CVE-2026-59883):**
One range only: `< 7.12.3`. No 6.x range and no 6.x patch. Installed version is 6.5.8. Upgrading to 7.x is a breaking change across the entire Goutte/Guzzle test driver stack. Package is dev-only (no `require` section in composer.json; pulled in via `pantheon-wordpress-upstream-tests -> behat/mink-goutte-driver -> fabpot/goutte -> guzzlehttp/guzzle`). Route: audit-ignore.

**guzzlehttp/psr7 (GHSA-c2w2-prh8-qm98 / CVE-2026-59882):**
One range only: `< 2.12.3`. No 1.x range and no 1.x patch. Installed version is 1.9.1. guzzle 6.x requires psr7 `^1.9`, so psr7 2.x is incompatible within this stack. Package is dev-only (same chain as guzzle above, one hop deeper). Route: audit-ignore.

## Release

**No release required for this change.** All four affected packages are dev-only:

- `brace-expansion` and `js-yaml` are npm devDependencies (transitive deps of grunt, a build tool). Neither is bundled or shipped with the plugin artifact.
- `guzzlehttp/guzzle` and `guzzlehttp/psr7` are composer dev-only (require-dev chain via behat test driver). The composer.json `require` section is empty; no vendor packages are shipped with the WordPress plugin.

Evidence: `composer.json` has no `require` block, only `require-dev`. The `package.json` has no `dependencies`, only `devDependencies`. Neither package is loaded at runtime on Pantheon.

## Test plan

- [ ] npm: `python3 -c "import json; lock=json.load(open('package-lock.json')); print(lock['packages']['node_modules/brace-expansion']['version'])"` returns `>= 1.1.16`
- [ ] npm: `python3 -c "import json; lock=json.load(open('package-lock.json')); print(lock['packages']['node_modules/js-yaml']['version'])"` returns `>= 3.15.0`
- [ ] composer: `composer audit` shows guzzle and psr7 in the "ignored" section with correct reasons, exit code 0 (or non-zero only due to other pre-existing advisories outside this batch)
- [ ] CI passes (PHP lint + PHPUnit; no JS test suite in this repo)


[VUL-24446]: https://getpantheon.atlassian.net/browse/VUL-24446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-24498]: https://getpantheon.atlassian.net/browse/VUL-24498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-25209]: https://getpantheon.atlassian.net/browse/VUL-25209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VUL-25645]: https://getpantheon.atlassian.net/browse/VUL-25645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ