### PR TITLE
fix: correct 5 typos across README, readme.txt and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please feel free to file issues there. Pull requests are also welcome!
 
 The `main` branch is the development branch which means it contains the next version to be released. `release` contains the corresponding stable development version. Always work on the `main` branch and open up PRs against `main`.
 
-We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `main` when merging, and to include the PR # in the commit message. PRs to `main` should also include any relevent updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `main`.
+We prefer to squash commits (i.e. avoid merge PRs) from a feature branch into `main` when merging, and to include the PR # in the commit message. PRs to `main` should also include any relevant updates to the changelog in readme.txt. For example, if a feature constitutes a minor or major version bump, that version update should be discussed and made as part of approving and merging the feature into `main`.
 
 `main` should be stable and usable, though possibly a few commits ahead of the public release on wp.org.
 
@@ -57,7 +57,7 @@ Note that dependencies are installed via Composer and the `vendor` directory is 
     * `git pull origin release`
     * `git checkout main`
     * `git rebase release`
-    * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new verison will be `1.2.4-dev`)
+    * Update the version number in all locations, incrementing the version by one patch version, and add the `-dev` flag (e.g. after releasing `1.2.3`, the new version will be `1.2.4-dev`)
     * Add a new `** X.Y.Z-dev **` heading to the changelog
     * `git add -A .`
     * `git commit -m "Prepare X.Y.Z-dev"`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A heads-up display into your Pantheon environment.
 [![Lint & Test](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml/badge.svg)](https://github.com/pantheon-systems/pantheon-hud/actions/workflows/lint-test.yml)
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#actively-maintained-support)
 
-This plugin provides situational awareness of the Pantheon plaform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.
+This plugin provides situational awareness of the Pantheon platform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.
 
 Pantheon HUD is in early stages of development. We want your feedback! [Create a Github issue](https://github.com/pantheon-systems/pantheon-hud/issues) with questions, feature requests, or bug reports.
 
@@ -56,7 +56,7 @@ By default, the Pantheon HUD shows dev, test and live. You can modify these valu
 
 ### 0.4.5 ###
 * Supports PHP 8.4 [[#153](https://github.com/pantheon-systems/pantheon-hud/pull/153/)]
-* Add Enviroment Filter
+* Add Environment Filter
 * Supports WordPress 6.9 [#173](https://github.com/pantheon-systems/pantheon-hud/pull/173/)
 
 ### 0.4.4 (December 6, 2024 ###

--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,7 @@ A heads-up display into your Pantheon environment.
 
 == Description ==
 
-This plugin provides situational awareness of the Pantheon plaform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.
+This plugin provides situational awareness of the Pantheon platform from within your WordPress dashboard. It's helpful to be reminded what environment you're in, as well as providing quick links to get back to Pantheon's dashboard, or to interface with your WordPress installation via the command line.
 
 Pantheon HUD is in early stages of development. We want your feedback! [Create a Github issue](https://github.com/pantheon-systems/pantheon-hud/issues) with questions, feature requests, or bug reports.
 


### PR DESCRIPTION
## Summary
Fixes 5 typos reported in issue #237 (detected via szepeviktor/typos-on-you GitHub Actions scan):

1. **README.md L19**: `plaform` → `platform` (Pantheon platform spelling)
2. **README.md L59**: `Enviroment` → `Environment` (changelog entry)
3. **readme.txt L15**: `plaform` → `platform` (same typo, WordPress plugin description)
4. **CONTRIBUTING.md L13**: `relevent` → `relevant` (changelog updates)
5. **CONTRIBUTING.md L60**: `verison` → `version` (release workflow instructions)

All fixes are minor spelling corrections with no behavioral changes.

## Testing
- No code logic changed, only documentation text
- Diff: 5 lines changed across 3 files

Fixes #237