### PR TITLE
ci: Group dependabot PRs by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     day: tuesday
   target-branch: main
   open-pull-requests-limit: 99
+  groups:
+    composer-minor-patch:
+      update-types:
+      - minor
+      - patch
   ignore:
   - dependency-name: phpunit/phpunit
     versions:
@@ -25,6 +30,11 @@ updates:
     day: tuesday
   target-branch: main
   open-pull-requests-limit: 99
+  groups:
+    npm-minor-patch:
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -33,3 +43,7 @@ updates:
     day: tuesday
   target-branch: main
   open-pull-requests-limit: 99
+  groups:
+    github-actions:
+      patterns:
+      - "*"


### PR DESCRIPTION
## Summary
- Groups composer and npm minor/patch updates into single PRs per ecosystem
- Groups all github-actions updates into a single PR
- Major version bumps for composer/npm remain ungrouped for individual review