### PR TITLE
SITE-5791: pin actions to Node 24 release SHAs

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build, tag and release
-        uses: pantheon-systems/plugin-release-actions/build-tag-release@c661c8c4d4b5034ba3bc39c4da62c37a7bb547c4 # main 2025-11-07T23:23:14Z
+        uses: pantheon-systems/plugin-release-actions/build-tag-release@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           generate_release_notes: "true"

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Create Draft Release PR
-        uses: pantheon-systems/plugin-release-actions/release-pr@c661c8c4d4b5034ba3bc39c4da62c37a7bb547c4 # main 2025-11-07T23:23:14Z
+        uses: pantheon-systems/plugin-release-actions/release-pr@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:
           gh_token: ${{ github.token }}
           readme_md: README.md

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -72,7 +72,7 @@ jobs:
           { composer config -g github-oauth.github.com "${GITHUB_TOKEN}"; } &>/dev/null
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@409451ede17f75acac08f42edc823fee6c435057 # v1.2.8
+        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -58,7 +58,7 @@ jobs:
         run: echo "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" >> $GITHUB_ENV
 
       - name: Install SSH key
-        uses: webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2 # v0.7.0
+        uses: webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 


### PR DESCRIPTION
GitHub removes Node.js 20 from the runners on 16 September 2026.

This pins every affected action reference in this repo to the commit SHA of a Node 24 release, with the version as a trailing comment. That covers both halves of SITE-5791 in one edit: the SHA pin removes the risk of a tag being repointed at a different commit, and the release bump clears the Node 20 removal.

Pinning `@v4` would not have been enough: v4 of `actions/checkout` and `actions/cache` runs on Node 20 itself, so each reference needed both a SHA and a version bump.

| File | Was | Now | Old runtime |
|---|---|---|---|
| `.github/workflows/test-behat.yml` | `webfactory/ssh-agent@836c84ec59a0e7bc0eabc79988384eb567561ee2` | `webfactory/ssh-agent@e83874834305fe9a4a2997156cb26c5de65a8555 # v0.10.0` | node16 |

Part of SITE-5791, under the CI standardization epic SITE-5778.

---

### Supersedes pending Dependabot PRs

This PR changes the same `uses:` lines as #248, now closed to avoid conflicting edits. Dependabot preserves whatever reference style it finds -- it bumps a tag to a newer tag and does not convert `@v4` into a SHA pin. The pinning has to happen here; Dependabot maintains the SHAs afterwards.


