### PR TITLE
SITE-5827: clear the Dependabot backlog

### DIFF
--- a/.github/workflows/build-tag-release.yml
+++ b/.github/workflows/build-tag-release.yml
@@ -13,7 +13,7 @@ jobs:
     name: Tag and Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build, tag and release
         uses: pantheon-systems/plugin-release-actions/build-tag-release@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -10,9 +10,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup PHP 8.4
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.4      
       - name: Install Composer dependencies
@@ -23,12 +23,12 @@ jobs:
     name: WP.org Plugin Validation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create build directory
         run: |
           mkdir -p build/pantheon-hud
           rsync -av --exclude-from=.distignore ./ build/pantheon-hud/
-      - uses: wordpress/plugin-check-action@6f5a57e173c065a394b78688f75df543e4011902 # v1.1.5
+      - uses: wordpress/plugin-check-action@10857da14b6c2246d15402b3e69f777edcf8c12e # v1.1.9
         with:
           build-dir: './build/pantheon-hud'
   validate-readme-spacing:
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: pantheon-systems/validate-readme-spacing@229ea162621009cf8e09bf2beba405017150130e # v1.0.5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pantheon-systems/validate-readme-spacing@13c5e619ef5fc39632292f1f5261ab31d1904208 # v1.0.6
   php8-compatibility:
     name: PHP 8.x Compatibility
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: PHP Compatibility
         uses: pantheon-systems/phpcompatibility-action@bd72eb001d4fb9817c9d6e1a157a71e287f3ff80 # dev 2023-10-04T16:54:18Z
         with:
@@ -61,16 +61,16 @@ jobs:
         image: ${{ matrix.php-version == '7.4' && 'mariadb:10.5' || 'mariadb:10.6' }}
     name: PHP ${{ matrix.php-version }} Unit Tests
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mysqli, zip, imagick
       - name: Start MySQL Service
         run: sudo systemctl start mysql
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/vendor
           key: test-phpunit-dependencies-${{ hashFiles('composer.json') }}-${{ matrix.php-version }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -13,7 +13,7 @@ jobs:
     name: Draft Release PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Create Draft Release PR
         uses: pantheon-systems/plugin-release-actions/release-pr@8c76f0613b094d9812da9257030e534c4d8eeb6c # v0.5.6
         with:

--- a/.github/workflows/test-behat.yml
+++ b/.github/workflows/test-behat.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.5'
           tools: composer
@@ -35,7 +35,7 @@ jobs:
           extensions: mbstring, intl, zip
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: vendor
           key: composer-deps-${{ hashFiles('composer.lock') }}
@@ -72,13 +72,13 @@ jobs:
           { composer config -g github-oauth.github.com "${GITHUB_TOKEN}"; } &>/dev/null
 
       - name: Install Terminus
-        uses: pantheon-systems/terminus-github-actions@b0a005d0e886678b25cb6cd7833cf8d8cf779900 # v1.2.9
+        uses: pantheon-systems/terminus-github-actions@8fb365801c4abd633407f65ecb475a540ddb38f1 # v1.2.10
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
 
       - name: Validate WordPress 'Tested Up To' version
         if: github.event_name == 'pull_request'
-        uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1
+        uses: jazzsequence/action-validate-plugin-version@754dfd0b2c86b788c3912c4b26a0e155acb5d2eb # v2.0.2
         with:
           branch: ${{ github.head_ref }}
           dry-run: 'true'

--- a/.github/workflows/tested-up-to.yml
+++ b/.github/workflows/tested-up-to.yml
@@ -11,9 +11,9 @@ jobs:
   validate-wp-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Validate Plugin Tested Up To Version
-        uses: jazzsequence/action-validate-plugin-version@6b8b403af6e9eefde9c36c0d342b717d5952b518 # v2.0.1
+        uses: jazzsequence/action-validate-plugin-version@754dfd0b2c86b788c3912c4b26a0e155acb5d2eb # v2.0.2
         with:
           filenames: 'readme.txt,README.md'
           branch: 'main'

--- a/.github/workflows/wordpress-plugin-deploy.yml
+++ b/.github/workflows/wordpress-plugin-deploy.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0 2025-01-21T15:30:29Z
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pantheon-hud",
       "version": "0.4.6-dev",
       "devDependencies": {
-        "grunt": "^1.6.2",
+        "grunt": "^1.6.3",
         "grunt-wp-readme-to-markdown": "^2"
       }
     },
@@ -374,9 +374,9 @@
       }
     },
     "node_modules/grunt": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.2.tgz",
-      "integrity": "sha512-bUzh5nA/P5L66ihXTDP6J5BGnMB/8lXJXejYWSbH4Y4TvWM9t2S39sggQDYYQlx06cYcCsmu63HMYHGCIzUVfg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.3.tgz",
+      "integrity": "sha512-ng0CbpyNp/ox5e5CBY9TkZgVdAL4wK+nBHO6rNE8cXGa5kM++Lxlp0MpFBVZbpgOR2oCp/91V+T3CZVSWWLqMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -390,7 +390,7 @@
         "grunt-legacy-log": "~3.0.0",
         "grunt-legacy-util": "~2.0.1",
         "iconv-lite": "~0.6.3",
-        "js-yaml": "~3.14.0",
+        "js-yaml": "^3.15.0",
         "minimatch": "^3.1.5",
         "nopt": "^5.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "readme": "grunt readme"
   },
   "devDependencies": {
-    "grunt": "^1.6.2",
+    "grunt": "^1.6.3",
     "grunt-wp-readme-to-markdown": "^2"
   },
   "overrides": {


### PR DESCRIPTION
Clears the open Dependabot backlog on this repo in one review.

Carries the Dependabot commits unchanged:
- the github-actions group, 7 updates ([#252](https://github.com/pantheon-systems/pantheon-hud/pull/252))
- grunt 1.6.2 to 1.6.3 ([#234](https://github.com/pantheon-systems/pantheon-hud/pull/234))

[#246](https://github.com/pantheon-systems/pantheon-hud/pull/246) bumps `wordpress/plugin-check-action` to the same SHA the github-actions group already carries, and [#217](https://github.com/pantheon-systems/pantheon-hud/pull/217) is already on `main`, which has symfony/yaml 6.4.43 and symfony/polyfill-intl-idn 1.38.1. Both close with nothing to merge.

https://getpantheon.atlassian.net/browse/SITE-5827
