### PR TITLE
SITE-5827: bump Tested up to 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: getpantheon, danielbachhuber, jazzs3quence, jspellman, pwtyler, metasim
 Tags: Pantheon, hosting, environment-indicator
 Requires at least: 4.9
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Stable tag: 0.4.6-dev
 License: GPLv2 or later


### PR DESCRIPTION
`readme.txt` said `Tested up to: 7.0`, which fails WP.org Plugin Validation now that 7.1 is current.

The plugin header carries no `Tested up to` line, so only `readme.txt` changes.

https://getpantheon.atlassian.net/browse/SITE-5827

--

Behat failing not required here. not a code change. 
